### PR TITLE
fix(api): handle zod validation errors in middleware, fixes #6

### DIFF
--- a/src/core/http/middlewares/with-zod-validation.ts
+++ b/src/core/http/middlewares/with-zod-validation.ts
@@ -2,6 +2,7 @@ import type { APIContext } from 'astro'
 import type { ZodType } from 'zod'
 import { ValidationError } from '@/core/errors/errors'
 import { ErrorCodes } from '@/core/errors/error-codes'
+import { mapErrorToHttp } from '@/core/errors/handle-error'
 
 type ValidatedHandler<T> = (
   context: APIContext & { validated: T }
@@ -24,11 +25,24 @@ export function withZodValidation<T>(schema: ZodType<T>) {
       const result = schema.safeParse(data)
 
       if (!result.success) {
-        throw new ValidationError(
+        const error = new ValidationError(
           ErrorCodes.VALIDATION_ERROR,
           'Invalid request',
           { issues: result.error.issues }
         )
+
+        const { status, body } = mapErrorToHttp(error)
+        const payload = {
+          data: null,
+          status,
+          error: body.message ?? 'Unexpected error',
+          meta: body.meta ?? {},
+        }
+
+        return new Response(JSON.stringify(payload), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        })
       }
 
       return handler({


### PR DESCRIPTION
# What changed
- Updated the validation middleware to handle Zod failures without throwing an unhandled error.
- When validation fails, the middleware now maps [ValidationError](through [mapErrorToHttp]
- Returns a consistent JSON 400 response using the same API error shape.
## Problem solved
- Previously, validation errors were thrown in middleware before endpoint-level [try/catch]blocks could run, so - centralized error mapping was bypassed and surfaced as unhandled endpoint errors.

## Expected behavior
- Invalid request validation now returns a controlled 400 response.
- No unhandled stack trace for known validation failures.
- Error payload format remains consistent across endpoints.
## Verification
- Project build passes.
- Manual test: [GET /api/anime?page=abc&limit=10] returns 400 Bad Request with the expected JSON error payload.
## Related issue
Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error handling to return properly formatted JSON responses with consistent error messaging instead of throwing exceptions, enhancing error reliability and consistency across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->