### PR TITLE
Fix/anime list request schema

### DIFF
--- a/src/domains/anime/schemas/anime-list.ts
+++ b/src/domains/anime/schemas/anime-list.ts
@@ -2,12 +2,17 @@ import { createApiResponseSchema } from '@/core/http/schemas/api-response'
 import { animeCardSchema } from '@/domains/anime/schemas/anime-card'
 import { z } from 'zod'
 export const animeFiltersParamsSchema = z.object({
-  page: z.coerce.number().optional().default(1),
-  limit: z.coerce.number().optional().default(10),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
   genre: z.string().optional(),
   status: z.string().optional(),
   rating: z.string().optional(),
-  year: z.coerce.number().optional(),
+  year: z.coerce
+    .number()
+    .int()
+    .min(1900)
+    .max(new Date().getFullYear())
+    .optional(),
   type: z.string().optional(),
   query: z.string().optional(),
 })

--- a/src/domains/anime/schemas/anime-list.ts
+++ b/src/domains/anime/schemas/anime-list.ts
@@ -2,12 +2,12 @@ import { createApiResponseSchema } from '@/core/http/schemas/api-response'
 import { animeCardSchema } from '@/domains/anime/schemas/anime-card'
 import { z } from 'zod'
 export const animeFiltersParamsSchema = z.object({
-  page: z.number().optional().default(1),
-  limit: z.number().optional().default(10),
+  page: z.coerce.number().optional().default(1),
+  limit: z.coerce.number().optional().default(10),
   genre: z.string().optional(),
   status: z.string().optional(),
   rating: z.string().optional(),
-  year: z.number().optional(),
+  year: z.coerce.number().optional(),
   type: z.string().optional(),
   query: z.string().optional(),
 })
@@ -17,6 +17,12 @@ export const animeFiltersSchema = animeFiltersParamsSchema.extend({
   status: z.array(z.string()).optional(),
   rating: z.array(z.string()).optional(),
   type: z.array(z.string()).optional(),
+})
+
+export const animeListRequestSchema = z.object({
+  params: z.object({}).optional().default({}),
+  query: animeFiltersParamsSchema,
+  body: z.unknown().optional(),
 })
 
 export const animeListResponseSchema = createApiResponseSchema(

--- a/src/pages/api/anime/index.ts
+++ b/src/pages/api/anime/index.ts
@@ -1,41 +1,42 @@
 import { mapErrorToHttp } from '@/core/errors/handle-error'
 import { withZodValidation } from '@/core/http/middlewares/with-zod-validation'
 import {
-  animeFiltersParamsSchema,
+  animeListRequestSchema,
   animeListResponseSchema,
 } from '@/domains/anime/schemas/anime-list'
 import { animeListService } from '@/domains/anime/services/anime-list'
 import type { APIRoute } from 'astro'
-export const GET: APIRoute = withZodValidation(animeFiltersParamsSchema)(
-  async ({ validated }) => {
-    try {
-      const { list: animeCards, total } =
-        await animeListService.getAnimeList(validated)
-      const payload = {
-        data: animeCards,
-        status: 200,
-        meta: {
-          page: validated.page,
-          total,
-          hasNext: validated.page * validated.limit < total,
-        },
-      }
-      const responseBody = animeListResponseSchema.parse(payload)
-      return new Response(JSON.stringify(responseBody), {
-        headers: { 'Content-Type': 'application/json' },
-      })
-    } catch (error) {
-      const { status, body } = mapErrorToHttp(error)
-      const payload = {
-        data: null,
-        status,
-        error: body.message ?? 'Unexpected error',
-        meta: body.meta ?? {},
-      }
-      return new Response(JSON.stringify(payload), {
-        status,
-        headers: { 'Content-Type': 'application/json' },
-      })
+export const GET: APIRoute = withZodValidation(animeListRequestSchema)(async ({
+  validated,
+}) => {
+  try {
+    const { list: animeCards, total } = await animeListService.getAnimeList(
+      validated.query
+    )
+    const payload = {
+      data: animeCards,
+      status: 200,
+      meta: {
+        page: validated.query.page,
+        total,
+        hasNext: validated.query.page * validated.query.limit < total,
+      },
     }
+    const responseBody = animeListResponseSchema.parse(payload)
+    return new Response(JSON.stringify(responseBody), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    const { status, body } = mapErrorToHttp(error)
+    const payload = {
+      data: null,
+      status,
+      error: body.message ?? 'Unexpected error',
+      meta: body.meta ?? {},
+    }
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
   }
-)
+})


### PR DESCRIPTION
# Changes:

- Updated animeFiltersParamsSchema to use z.coerce.number() for page, limit, and year parameters to properly handle string inputs from query params

- Added new animeListRequestSchema combining params, query (using animeFiltersParamsSchema), and optional body

- Updated GET /api/anime handler to use animeListRequestSchema and extract filters from validated.query

## Impact:

- ✅ Better type coercion for numeric query parameters

- ✅ Consistent request validation structure across anime API endpoints

- ✅ No breaking changes - maintains backward compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API now accepts numeric filters provided as strings and coerces them so pagination, limit, and year filtering work reliably.
* **Validation**
  * Page must be ≥1, limit is constrained to 1–100, and year is restricted to 1900–current year; sensible defaults retained.
* **Behavior**
  * Request filter values are now consistently read from the query portion of API requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->