### PR TITLE
feat(auth): Add auth domain with explicit session routes

### DIFF
--- a/src/domains/auth/errors/index.ts
+++ b/src/domains/auth/errors/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Authentication domain error exports.
+ *
+ * @module domains/auth/errors
+ * @remarks
+ * Typed {@link AuthError} subclasses for credential, registration, and session failures.
+ * Each error carries a stable {@link ErrorCode} that {@link mapErrorToHttp} maps to HTTP
+ * status codes (401 for invalid credentials and expired sessions, 400 for registration
+ * validation failures).
+ *
+ * @see {@link InvalidCredentialsError} — rejected email/password sign-in
+ * @see {@link SessionExpiredError} — expired or invalid session token
+ * @see {@link RegistrationFailedError} — duplicate account or sign-up validation failure
+ * @see {@link mapErrorToHttp} — HTTP status mapping for auth error codes
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   InvalidCredentialsError,
+ *   SessionExpiredError,
+ *   RegistrationFailedError,
+ * } from '@domains/auth/errors'
+ *
+ * try {
+ *   await credentialsService.login(input, headers)
+ * } catch (error) {
+ *   if (error instanceof InvalidCredentialsError) {
+ *     const { status } = mapErrorToHttp(error) // 401
+ *   }
+ * }
+ * ```
+ */
+
+/** Error raised when email/password authentication fails. */
+export * from './invalid-credentials-error'
+/** Error raised when an authenticated session is no longer valid. */
+export * from './session-expired-error'
+/** Error raised when user registration cannot be completed. */
+export * from './registration-failed-error'

--- a/src/domains/auth/errors/invalid-credentials-error.ts
+++ b/src/domains/auth/errors/invalid-credentials-error.ts
@@ -1,0 +1,68 @@
+/**
+ * Error raised when email/password authentication fails.
+ *
+ * @module domains/auth/errors/invalid-credentials-error
+ * @remarks
+ * Thrown when Better Auth rejects a sign-in attempt (via {@link mapBetterAuthError}) or when
+ * credential validation fails upstream. Uses {@link ErrorCodes.AUTH_INVALID_TOKEN} so clients
+ * receive a generic message without revealing whether the email or password was wrong — a
+ * standard security practice for credential handling.
+ *
+ * **HTTP mapping via {@link mapErrorToHttp}**
+ * - Error code: `AUTH_INVALID_TOKEN`
+ * - HTTP status: **401 Unauthorized**
+ * - Logged at `warn` severity; not reported to Sentry
+ *
+ * @see {@link credentialsService.login} — primary caller via Better Auth `signInEmail`
+ * @see {@link mapBetterAuthError} — maps Better Auth "invalid credential" messages
+ * @see {@link mapErrorToHttp} — converts to 401 response body `{ code, message, meta }`
+ */
+import { AuthError } from '@shared/errors/app-error'
+import { ErrorCodes } from '@shared/errors/codes'
+
+/**
+ * Thrown when supplied email/password credentials are rejected by Better Auth.
+ *
+ * @remarks
+ * Carries {@link ErrorCodes.AUTH_INVALID_TOKEN} with the fixed client message
+ * `"Invalid email or password"`. Optional `details` preserves the original Better Auth
+ * error for server-side logging without exposing it to clients.
+ *
+ * @extends AuthError
+ *
+ * @see {@link ErrorCodes.AUTH_INVALID_TOKEN}
+ * @see {@link mapErrorToHttp} — maps to HTTP 401
+ *
+ * @example
+ * ```typescript
+ * import { InvalidCredentialsError } from '@domains/auth/errors'
+ * import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
+ *
+ * const error = new InvalidCredentialsError({ reason: 'bad password' })
+ * const { status, body } = mapErrorToHttp(error)
+ * // status === 401
+ * // body.code === 'AUTH_INVALID_TOKEN'
+ * ```
+ */
+export class InvalidCredentialsError extends AuthError {
+  /**
+   * Creates an invalid-credentials error for a failed sign-in attempt.
+   *
+   * @param details - Optional underlying Better Auth error or diagnostic context
+   *   stored in `error.details` for logging; not exposed verbatim to API clients
+   *
+   * @remarks
+   * Default message is `"Invalid email or password"` to avoid account enumeration.
+   * Error code is {@link ErrorCodes.AUTH_INVALID_TOKEN}.
+   *
+   * @see {@link mapErrorToHttp} — HTTP 401 Unauthorized
+   *
+   * @example
+   * ```typescript
+   * throw new InvalidCredentialsError(originalBetterAuthError)
+   * ```
+   */
+  constructor(details?: unknown) {
+    super(ErrorCodes.AUTH_INVALID_TOKEN, 'Invalid email or password', details)
+  }
+}

--- a/src/domains/auth/errors/registration-failed-error.ts
+++ b/src/domains/auth/errors/registration-failed-error.ts
@@ -1,0 +1,68 @@
+/**
+ * Error raised when user registration cannot be completed.
+ *
+ * @module domains/auth/errors/registration-failed-error
+ * @remarks
+ * Thrown when Better Auth `signUpEmail` fails due to duplicate accounts, validation
+ * constraints, or other sign-up rejection. Uses {@link ErrorCodes.VALIDATION_ERROR} to
+ * signal client-correctable input problems rather than an authentication/session failure.
+ *
+ * **HTTP mapping via {@link mapErrorToHttp}**
+ * - Error code: `VALIDATION_ERROR`
+ * - Intended semantic: **400 Bad Request** (validation / duplicate account)
+ * - Extends {@link AuthError}; unrecognized auth codes fall through the auth mapper — callers
+ *   should handle this error explicitly or ensure API wrappers map it appropriately
+ *
+ * @see {@link credentialsService.register} — primary caller via Better Auth `signUpEmail`
+ * @see {@link mapBetterAuthError} — maps "already exists" and "duplicate" message patterns
+ * @see {@link mapErrorToHttp} — HTTP status mapping for error codes
+ */
+import { AuthError } from '@shared/errors/app-error'
+import { ErrorCodes } from '@shared/errors/codes'
+
+/**
+ * Thrown when sign-up fails due to validation or duplicate account issues.
+ *
+ * @remarks
+ * Typically produced by {@link mapBetterAuthError} when Better Auth reports an existing
+ * account (`"already exists"`, `"duplicate"` in the message). Carries
+ * {@link ErrorCodes.VALIDATION_ERROR} so API layers can return a 400-class response with
+ * a human-readable `message` describing the failure reason.
+ *
+ * @extends AuthError
+ *
+ * @see {@link ErrorCodes.VALIDATION_ERROR}
+ * @see {@link RegisterInput} — validated registration payload shape
+ *
+ * @example
+ * ```typescript
+ * import { RegistrationFailedError } from '@domains/auth/errors'
+ *
+ * throw new RegistrationFailedError('An account with this email already exists', cause)
+ * ```
+ */
+export class RegistrationFailedError extends AuthError {
+  /**
+   * Creates a registration-failure error for a rejected sign-up attempt.
+   *
+   * @param message - Human-readable failure reason forwarded to API clients;
+   *   defaults to `"Registration failed"`
+   * @param details - Optional underlying Better Auth error or diagnostic context
+   *   stored in `error.details` for server-side logging
+   *
+   * @remarks
+   * Error code is {@link ErrorCodes.VALIDATION_ERROR}. Common causes include duplicate
+   * email addresses and Better Auth field validation rejections.
+   *
+   * @see {@link credentialsService.register} — Better Auth `signUpEmail` wrapper
+   * @see {@link mapBetterAuthError} — automatic mapping from Better Auth messages
+   *
+   * @example
+   * ```typescript
+   * throw new RegistrationFailedError('Email already registered', originalError)
+   * ```
+   */
+  constructor(message = 'Registration failed', details?: unknown) {
+    super(ErrorCodes.VALIDATION_ERROR, message, details)
+  }
+}

--- a/src/domains/auth/errors/session-expired-error.ts
+++ b/src/domains/auth/errors/session-expired-error.ts
@@ -1,0 +1,68 @@
+/**
+ * Error raised when an authenticated session is no longer valid.
+ *
+ * @module domains/auth/errors/session-expired-error
+ * @remarks
+ * Thrown when Better Auth reports that the session token or cookie has expired during
+ * {@link sessionService.getSession} or related session resolution. Clients should treat
+ * this as a signal to re-authenticate rather than retry the same request unchanged.
+ *
+ * **HTTP mapping via {@link mapErrorToHttp}**
+ * - Error code: `AUTH_SESSION_EXPIRED`
+ * - HTTP status: **401 Unauthorized**
+ * - Logged at `warn` severity; not reported to Sentry
+ *
+ * @see {@link sessionService.getSession} — Better Auth `getSession` wrapper
+ * @see {@link mapBetterAuthError} — maps Better Auth "session expired" messages
+ * @see {@link mapErrorToHttp} — converts to 401 response body `{ code, message, meta }`
+ */
+import { AuthError } from '@shared/errors/app-error'
+import { ErrorCodes } from '@shared/errors/codes'
+
+/**
+ * Thrown when the current session has expired or is no longer accepted by Better Auth.
+ *
+ * @remarks
+ * Carries {@link ErrorCodes.AUTH_SESSION_EXPIRED} with the fixed client message
+ * `"Session has expired"`. Part of the session flow: after this error, the client
+ * should clear local session state and redirect to login.
+ *
+ * @extends AuthError
+ *
+ * @see {@link ErrorCodes.AUTH_SESSION_EXPIRED}
+ * @see {@link mapErrorToHttp} — maps to HTTP 401
+ *
+ * @example
+ * ```typescript
+ * import { SessionExpiredError } from '@domains/auth/errors'
+ * import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
+ *
+ * const error = new SessionExpiredError()
+ * const { status, body } = mapErrorToHttp(error)
+ * // status === 401
+ * // body.code === 'AUTH_SESSION_EXPIRED'
+ * ```
+ */
+export class SessionExpiredError extends AuthError {
+  /**
+   * Creates a session-expired error for an invalid or timed-out session.
+   *
+   * @param details - Optional underlying Better Auth error or session metadata
+   *   stored in `error.details` for logging; not exposed verbatim to API clients
+   *
+   * @remarks
+   * Default message is `"Session has expired"`. Error code is
+   * {@link ErrorCodes.AUTH_SESSION_EXPIRED}.
+   *
+   * @see {@link sessionService.getSession} — session lookup that may throw this error
+   * @see {@link mapErrorToHttp} — HTTP 401 Unauthorized
+   *
+   * @example
+   * ```typescript
+   * throw new SessionExpiredError(originalBetterAuthError)
+   * ```
+   */
+  constructor(details?: unknown) {
+    super(ErrorCodes.AUTH_SESSION_EXPIRED, 'Session has expired', details)
+  }
+}

--- a/src/domains/auth/index.ts
+++ b/src/domains/auth/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Public entry point for the authentication domain module.
+ *
+ * @module domains/auth
+ * @remarks
+ * Re-exports the auth domain surface: typed errors, middleware helpers, Zod schemas,
+ * Better Auth service wrappers, input types, and error-mapping utilities. Consumers should
+ * import from this barrel rather than deep paths to keep session flow and credential handling
+ * consistent across API routes and Astro middleware.
+ *
+ * **Better Auth integration**
+ * - {@link credentialsService} — email/password sign-in and sign-up via `signInEmail` / `signUpEmail`
+ * - {@link sessionService} — session lookup and sign-out via `getSession` / `signOut`
+ * - {@link resolveAuthActor} — populates `App.Locals` user/session from request headers
+ * - {@link mapBetterAuthError} — normalizes Better Auth failures into domain {@link AuthError} subclasses
+ *
+ * @see {@link credentialsService} — credential-based authentication
+ * @see {@link sessionService} — session lifecycle operations
+ * @see {@link resolveAuthActor} — Astro middleware actor resolution
+ * @see {@link mapBetterAuthError} — Better Auth error normalization
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   credentialsService,
+ *   sessionService,
+ *   loginSchema,
+ *   InvalidCredentialsError,
+ * } from '@domains/auth'
+ *
+ * const session = await sessionService.getSession(request.headers)
+ * ```
+ */
+
+/** Authentication domain error classes and factories. */
+export * from './errors'
+/** Middleware helpers for resolving authenticated actors. */
+export * from './middleware'
+/** Zod schemas and inferred input types for auth API payloads. */
+export * from './schemas'
+/** Better Auth service wrappers for credentials and sessions. */
+export * from './services'
+/** Re-exported authentication input types. */
+export * from './types'
+/** Utilities for mapping Better Auth errors to domain errors. */
+export * from './utils'

--- a/src/domains/auth/middleware/index.ts
+++ b/src/domains/auth/middleware/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Authentication middleware exports.
+ *
+ * @module domains/auth/middleware
+ * @remarks
+ * Helpers for resolving the authenticated actor (user + session) in Astro middleware and
+ * server routes. These utilities read Better Auth session cookies from incoming headers
+ * without throwing — suitable for optional-auth page rendering.
+ *
+ * @see {@link resolveAuthActor} — loads `App.Locals.user` and `App.Locals.session`
+ * @see {@link sessionService.getSession} — throwing variant for API routes
+ *
+ * @example
+ * ```typescript
+ * import { resolveAuthActor } from '@domains/auth/middleware'
+ *
+ * const { user, session } = await resolveAuthActor(Astro.request.headers)
+ * Astro.locals.user = user
+ * Astro.locals.session = session
+ * ```
+ */
+
+/** Resolves the current user and session for Astro locals. */
+export * from './resolve-auth-actor'

--- a/src/domains/auth/middleware/resolve-auth-actor.ts
+++ b/src/domains/auth/middleware/resolve-auth-actor.ts
@@ -1,0 +1,84 @@
+/**
+ * Resolves the authenticated actor for Astro middleware and API routes.
+ *
+ * @module domains/auth/middleware/resolve-auth-actor
+ * @remarks
+ * Non-throwing session resolver intended for Astro middleware where unauthenticated
+ * visitors are expected. Calls Better Auth `getSession` directly (not via
+ * {@link sessionService}) and returns `null` user/session on any failure — including
+ * expired sessions — so pages can render without a hard redirect.
+ *
+ * For API routes that must enforce authentication, prefer {@link sessionService.getSession}
+ * which throws {@link SessionExpiredError} and other typed errors mappable via
+ * {@link mapErrorToHttp}.
+ *
+ * @see {@link sessionService.getSession} — throwing session lookup for API enforcement
+ * @see {@link credentialsService.login} — establishes the session this function reads
+ */
+import { auth } from '@lib/auth/server'
+
+type SessionLocals = Pick<App.Locals, 'user' | 'session'>
+
+/**
+ * Loads the current user and session from Better Auth request cookies/headers.
+ *
+ * @param requestHeaders - Incoming request headers (typically `Astro.request.headers`
+ *   or `Request.headers` in API routes)
+ * @returns User and session locals compatible with `App.Locals`, or `null` values when
+ *   unauthenticated or when session resolution fails for any reason
+ *
+ * @remarks
+ * **Session flow**
+ * 1. Forwards headers to `auth.api.getSession({ headers })`
+ * 2. Extracts `user` and `session` from the Better Auth response
+ * 3. On any error (network, expired token, malformed cookie), returns `{ user: null, session: null }`
+ *    instead of throwing — safe for public pages with optional auth UI
+ *
+ * **Security note:** Swallowing errors prevents middleware crashes but means expired sessions
+ * appear as logged-out rather than triggering a 401. Use {@link sessionService} in protected
+ * API handlers when explicit auth failure responses are required.
+ *
+ * @see {@link sessionService.getSession} — strict session lookup with typed errors
+ * @see {@link sessionResponseSchema} — expected Better Auth session response shape
+ *
+ * @example
+ * ```typescript
+ * // astro middleware
+ * import { resolveAuthActor } from '@domains/auth/middleware/resolve-auth-actor'
+ *
+ * export const onRequest = defineMiddleware(async (context, next) => {
+ *   const { user, session } = await resolveAuthActor(context.request.headers)
+ *   context.locals.user = user
+ *   context.locals.session = session
+ *   return next()
+ * })
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // optional auth in a page
+ * const { user } = await resolveAuthActor(Astro.request.headers)
+ * if (user) {
+ *   // show authenticated nav
+ * }
+ * ```
+ */
+export async function resolveAuthActor(
+  requestHeaders: Headers
+): Promise<SessionLocals> {
+  try {
+    const sessionData = await auth.api.getSession({
+      headers: requestHeaders,
+    })
+
+    return {
+      user: sessionData?.user ?? null,
+      session: sessionData?.session ?? null,
+    }
+  } catch {
+    return {
+      user: null,
+      session: null,
+    }
+  }
+}

--- a/src/domains/auth/schemas/index.ts
+++ b/src/domains/auth/schemas/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Authentication schema exports.
+ *
+ * @module domains/auth/schemas
+ * @remarks
+ * Zod schemas for validating authentication API request bodies and session response
+ * shapes. Used by HTTP route wrappers ({@link withZodValidation}) before delegating to
+ * {@link credentialsService} or {@link sessionService}.
+ *
+ * @see {@link loginSchema} — email/password login validation
+ * @see {@link registerSchema} — email/password registration validation
+ * @see {@link sessionResponseSchema} — Better Auth session response shape
+ * @see {@link LoginInput} — inferred login body type
+ * @see {@link RegisterInput} — inferred registration body type
+ *
+ * @example
+ * ```typescript
+ * import { loginSchema, type LoginInput } from '@domains/auth/schemas'
+ *
+ * const parsed = loginSchema.parse({ body: { email: 'a@b.com', password: '12345678' } })
+ * const input: LoginInput = parsed.body
+ * ```
+ */
+
+/** Zod schemas and inferred types for login and registration payloads. */
+export * from './login-schema'

--- a/src/domains/auth/schemas/login-schema.ts
+++ b/src/domains/auth/schemas/login-schema.ts
@@ -1,0 +1,164 @@
+/**
+ * Zod schemas for authentication API payloads.
+ *
+ * @module domains/auth/schemas/login-schema
+ * @remarks
+ * Validates request bodies for Better Auth email/password flows before they reach
+ * {@link credentialsService}. Password minimum length aligns with common credential
+ * security baselines; email fields use Zod's built-in RFC-style email validation.
+ *
+ * @see {@link credentialsService.login} — consumes {@link LoginInput}
+ * @see {@link credentialsService.register} — consumes {@link RegisterInput}
+ * @see {@link sessionResponseSchema} — validates session lookup responses
+ * @see {@link withZodValidation} — HTTP wrapper that applies these schemas
+ */
+import { z } from 'zod'
+
+/**
+ * Validates email/password login request bodies.
+ *
+ * @remarks
+ * **Fields** (`body`):
+ * - `email` — `string`, must be a valid email address (`z.string().email()`)
+ * - `password` — `string`, minimum 8 characters (`z.string().min(8)`)
+ *
+ * Wraps fields in a top-level `body` key to match API route validation conventions.
+ *
+ * @see {@link LoginInput} — inferred TypeScript type for `body`
+ * @see {@link credentialsService.login} — Better Auth `signInEmail` consumer
+ *
+ * @example
+ * ```typescript
+ * const { body } = loginSchema.parse({
+ *   body: { email: 'user@example.com', password: 'secret123' },
+ * })
+ * await credentialsService.login(body, request.headers)
+ * ```
+ */
+export const loginSchema = z.object({
+  body: z.object({
+    /** User email address; validated as RFC-style email string. */
+    email: z.string().email(),
+    /** Plain-text password; minimum 8 characters. */
+    password: z.string().min(8),
+  }),
+})
+
+/**
+ * Validates email/password registration request bodies.
+ *
+ * @remarks
+ * **Fields** (`body`):
+ * - `email` — `string`, must be a valid email address (`z.string().email()`)
+ * - `password` — `string`, minimum 8 characters (`z.string().min(8)`)
+ * - `name` — `string`, minimum 1 non-empty character (`z.string().min(1)`)
+ *
+ * Wraps fields in a top-level `body` key to match API route validation conventions.
+ *
+ * @see {@link RegisterInput} — inferred TypeScript type for `body`
+ * @see {@link credentialsService.register} — Better Auth `signUpEmail` consumer
+ *
+ * @example
+ * ```typescript
+ * const { body } = registerSchema.parse({
+ *   body: { email: 'new@example.com', password: 'secret123', name: 'Alice' },
+ * })
+ * await credentialsService.register(body, request.headers)
+ * ```
+ */
+export const registerSchema = z.object({
+  body: z.object({
+    /** Account email address; validated as RFC-style email string. */
+    email: z.string().email(),
+    /** Account password; minimum 8 characters. */
+    password: z.string().min(8),
+    /** Display name; required, at least one character. */
+    name: z.string().min(1),
+  }),
+})
+
+/**
+ * Validates session lookup responses from Better Auth `getSession`.
+ *
+ * @remarks
+ * **Fields**:
+ * - `user` — nullable object:
+ *   - `id` — `string`, user identifier
+ *   - `email` — `string`, user email
+ *   - `name` — `string`, display name
+ * - `session` — nullable object:
+ *   - `id` — `string`, session identifier
+ *   - `userId` — `string`, owning user id
+ *   - `expiresAt` — `Date`, coerced from ISO string via `z.coerce.date()`
+ *
+ * Both `user` and `session` are `null` when the request is unauthenticated.
+ *
+ * @see {@link sessionService.getSession} — produces data matching this shape
+ * @see {@link resolveAuthActor} — extracts `user` and `session` for Astro locals
+ *
+ * @example
+ * ```typescript
+ * const sessionData = await sessionService.getSession(request.headers)
+ * const validated = sessionResponseSchema.parse(sessionData)
+ * ```
+ */
+export const sessionResponseSchema = z.object({
+  user: z
+    .object({
+      /** Better Auth user identifier. */
+      id: z.string(),
+      /** User email address. */
+      email: z.string(),
+      /** User display name. */
+      name: z.string(),
+    })
+    .nullable(),
+  session: z
+    .object({
+      /** Better Auth session identifier. */
+      id: z.string(),
+      /** ID of the user this session belongs to. */
+      userId: z.string(),
+      /** Session expiration timestamp (coerced to Date). */
+      expiresAt: z.coerce.date(),
+    })
+    .nullable(),
+})
+
+/**
+ * Parsed login request body after {@link loginSchema} validation.
+ *
+ * @remarks
+ * Inferred as `{ email: string; password: string }`. Passed directly to
+ * Better Auth `signInEmail` via {@link credentialsService.login}.
+ *
+ * @see {@link loginSchema} — source schema
+ * @see {@link credentialsService.login} — consumer
+ *
+ * @example
+ * ```typescript
+ * const input: LoginInput = { email: 'user@example.com', password: 'password123' }
+ * ```
+ */
+export type LoginInput = z.infer<typeof loginSchema>['body']
+
+/**
+ * Parsed registration request body after {@link registerSchema} validation.
+ *
+ * @remarks
+ * Inferred as `{ email: string; password: string; name: string }`. Passed directly to
+ * Better Auth `signUpEmail` via {@link credentialsService.register}.
+ *
+ * @see {@link registerSchema} — source schema
+ * @see {@link credentialsService.register} — consumer
+ *
+ * @example
+ * ```typescript
+ * const input: RegisterInput = {
+ *   email: 'new@example.com',
+ *   password: 'password123',
+ *   name: 'Alice',
+ * }
+ * ```
+ */
+export type RegisterInput = z.infer<typeof registerSchema>['body']

--- a/src/domains/auth/services/credentials-service.ts
+++ b/src/domains/auth/services/credentials-service.ts
@@ -1,0 +1,149 @@
+/**
+ * Credential-based authentication via Better Auth.
+ *
+ * @module domains/auth/services/credentials-service
+ * @remarks
+ * Wraps Better Auth email/password endpoints for login and registration. Request headers
+ * carry session cookies into Better Auth; returned headers must be forwarded on the HTTP
+ * response so new sessions are persisted in the browser. All failures pass through
+ * {@link mapBetterAuthError} for typed, security-conscious error messages.
+ *
+ * **Better Auth API calls**
+ * - {@link credentialsService.login} → `auth.api.signInEmail`
+ * - {@link credentialsService.register} → `auth.api.signUpEmail`
+ *
+ * @see {@link sessionService} — session read/terminate after successful sign-in
+ * @see {@link loginSchema} — Zod validation for login payloads
+ * @see {@link registerSchema} — Zod validation for registration payloads
+ * @see {@link mapBetterAuthError} — error normalization layer
+ */
+import { auth } from '@lib/auth/server'
+import type { LoginInput, RegisterInput } from '@domains/auth/schemas'
+import { mapBetterAuthError } from '@domains/auth/utils/map-better-auth-error-util'
+
+type AuthResult<T> = {
+  data: T
+  headers: Headers
+}
+
+/**
+ * Better Auth wrapper for email/password sign-in and sign-up.
+ *
+ * @remarks
+ * Each method calls the corresponding Better Auth server API with `returnHeaders: true`
+ * so Set-Cookie headers from session creation are available to route handlers.
+ *
+ * @see {@link credentialsService.login} — `signInEmail`
+ * @see {@link credentialsService.register} — `signUpEmail`
+ *
+ * @example
+ * ```typescript
+ * import { credentialsService } from '@domains/auth/services/credentials-service'
+ *
+ * const { data, headers } = await credentialsService.login(
+ *   { email: 'user@example.com', password: 'securepass' },
+ *   request.headers,
+ * )
+ * return new Response(JSON.stringify(data), { headers })
+ * ```
+ */
+export const credentialsService = {
+  /**
+   * Authenticates a user with email and password via Better Auth `signInEmail`.
+   *
+   * @param input - Validated login credentials ({@link LoginInput})
+   * @param requestHeaders - Incoming request headers containing session cookies
+   * @returns Auth payload from Better Auth plus response headers to forward (including Set-Cookie)
+   *
+   * @throws {InvalidCredentialsError} When Better Auth rejects credentials (mapped from
+   *   messages containing `"invalid"` and `"credential"`)
+   * @throws {AuthError} When Better Auth returns an unmapped failure (e.g. `AUTH_REQUIRED`,
+   *   `AUTH_FORBIDDEN`) via {@link mapBetterAuthError}
+   *
+   * @remarks
+   * Calls `auth.api.signInEmail({ body, headers, returnHeaders: true })`. On success,
+   * `data` contains the Better Auth sign-in response; `headers` must be merged into the
+   * outgoing HTTP response for session cookies to persist.
+   *
+   * @see {@link loginSchema} — request validation before calling this method
+   * @see {@link mapBetterAuthError} — converts raw Better Auth errors to domain errors
+   * @see {@link mapErrorToHttp} — HTTP 401 for {@link InvalidCredentialsError}
+   *
+   * @example
+   * ```typescript
+   * const result = await credentialsService.login(
+   *   { email: 'user@example.com', password: 'password123' },
+   *   request.headers,
+   * )
+   * // Forward result.headers on the Response
+   * ```
+   */
+  async login(
+    input: LoginInput,
+    requestHeaders: Headers
+  ): Promise<AuthResult<unknown>> {
+    try {
+      const result = await auth.api.signInEmail({
+        body: input,
+        headers: requestHeaders,
+        returnHeaders: true,
+      })
+
+      return {
+        data: result.response,
+        headers: result.headers,
+      }
+    } catch (error) {
+      throw mapBetterAuthError(error)
+    }
+  },
+
+  /**
+   * Creates a new user account with email and password via Better Auth `signUpEmail`.
+   *
+   * @param input - Validated registration fields ({@link RegisterInput})
+   * @param requestHeaders - Incoming request headers for session cookie context
+   * @returns Auth payload from Better Auth plus response headers to forward (including Set-Cookie)
+   *
+   * @throws {RegistrationFailedError} When the account already exists or sign-up validation
+   *   fails (mapped from messages containing `"already exists"` or `"duplicate"`)
+   * @throws {AuthError} When Better Auth returns an unmapped failure via {@link mapBetterAuthError}
+   *
+   * @remarks
+   * Calls `auth.api.signUpEmail({ body, headers, returnHeaders: true })`. Successful
+   * registration may establish an authenticated session immediately; forward returned
+   * headers so the client receives session cookies.
+   *
+   * @see {@link registerSchema} — request validation before calling this method
+   * @see {@link mapBetterAuthError} — converts raw Better Auth errors to domain errors
+   * @see {@link RegistrationFailedError} — duplicate email and validation failures
+   *
+   * @example
+   * ```typescript
+   * const result = await credentialsService.register(
+   *   { email: 'new@example.com', password: 'password123', name: 'New User' },
+   *   request.headers,
+   * )
+   * return new Response(JSON.stringify(result.data), { headers: result.headers })
+   * ```
+   */
+  async register(
+    input: RegisterInput,
+    requestHeaders: Headers
+  ): Promise<AuthResult<unknown>> {
+    try {
+      const result = await auth.api.signUpEmail({
+        body: input,
+        headers: requestHeaders,
+        returnHeaders: true,
+      })
+
+      return {
+        data: result.response,
+        headers: result.headers,
+      }
+    } catch (error) {
+      throw mapBetterAuthError(error)
+    }
+  },
+}

--- a/src/domains/auth/services/index.ts
+++ b/src/domains/auth/services/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Authentication service exports.
+ *
+ * @module domains/auth/services
+ * @remarks
+ * Better Auth service wrappers that isolate API route handlers from direct `auth.api` calls.
+ * Both services forward incoming request headers (cookies) and return response headers so
+ * session cookies set by Better Auth propagate back to the client.
+ *
+ * @see {@link credentialsService} — `signInEmail` and `signUpEmail`
+ * @see {@link sessionService} — `getSession` and `signOut`
+ * @see {@link mapBetterAuthError} — shared error normalization for all service methods
+ *
+ * @example
+ * ```typescript
+ * import { credentialsService, sessionService } from '@domains/auth/services'
+ *
+ * const loginResult = await credentialsService.login(body, request.headers)
+ * const session = await sessionService.getSession(request.headers)
+ * ```
+ */
+
+/** Credential-based sign-in and registration via Better Auth. */
+export * from './credentials-service'
+/** Session lookup and sign-out via Better Auth. */
+export * from './session-service'

--- a/src/domains/auth/services/session-service.ts
+++ b/src/domains/auth/services/session-service.ts
@@ -1,0 +1,125 @@
+/**
+ * Session lifecycle operations via Better Auth.
+ *
+ * @module domains/auth/services/session-service
+ * @remarks
+ * Wraps Better Auth session endpoints for reading and terminating authenticated sessions.
+ * Session state is cookie-backed; always pass the incoming request headers so Better Auth
+ * can read and update session tokens securely.
+ *
+ * **Better Auth API calls**
+ * - {@link sessionService.getSession} → `auth.api.getSession`
+ * - {@link sessionService.logout} → `auth.api.signOut`
+ *
+ * @see {@link credentialsService} — establishes sessions after sign-in/sign-up
+ * @see {@link resolveAuthActor} — middleware variant that swallows session errors
+ * @see {@link sessionResponseSchema} — Zod shape for session lookup responses
+ * @see {@link mapBetterAuthError} — error normalization layer
+ */
+import { auth } from '@lib/auth/server'
+import { mapBetterAuthError } from '@domains/auth/utils/map-better-auth-error-util'
+
+type AuthResult<T> = {
+  data: T
+  headers: Headers
+}
+
+/**
+ * Better Auth wrapper for session lookup and sign-out.
+ *
+ * @remarks
+ * Unlike {@link resolveAuthActor}, this service throws typed errors on session failures
+ * so API routes can return appropriate HTTP status codes via {@link mapErrorToHttp}.
+ *
+ * @see {@link sessionService.getSession} — `getSession`
+ * @see {@link sessionService.logout} — `signOut`
+ *
+ * @example
+ * ```typescript
+ * import { sessionService } from '@domains/auth/services/session-service'
+ *
+ * const session = await sessionService.getSession(request.headers)
+ * if (!session) {
+ *   // unauthenticated
+ * }
+ * ```
+ */
+export const sessionService = {
+  /**
+   * Resolves the current session from request cookies/headers via Better Auth `getSession`.
+   *
+   * @param requestHeaders - Incoming request headers containing session cookies
+   * @returns Session and user objects from Better Auth, or `null` when unauthenticated
+   *
+   * @throws {SessionExpiredError} When Better Auth reports an expired session (mapped from
+   *   messages containing `"session"` and `"expired"`)
+   * @throws {AuthError} When Better Auth returns an unmapped failure via {@link mapBetterAuthError}
+   *
+   * @remarks
+   * Calls `auth.api.getSession({ headers })`. A `null` return indicates no active session
+   * without an error — distinct from {@link SessionExpiredError}, which signals an invalid
+   * or expired token that should trigger re-authentication.
+   *
+   * @see {@link sessionResponseSchema} — expected response shape for validation
+   * @see {@link resolveAuthActor} — non-throwing middleware alternative
+   * @see {@link mapErrorToHttp} — HTTP 401 for {@link SessionExpiredError}
+   *
+   * @example
+   * ```typescript
+   * const sessionData = await sessionService.getSession(request.headers)
+   * if (sessionData?.user) {
+   *   console.log(sessionData.user.email)
+   * }
+   * ```
+   */
+  async getSession(requestHeaders: Headers) {
+    try {
+      const session = await auth.api.getSession({
+        headers: requestHeaders,
+      })
+
+      return session
+    } catch (error) {
+      throw mapBetterAuthError(error)
+    }
+  },
+
+  /**
+   * Signs the user out and clears session cookies via Better Auth `signOut`.
+   *
+   * @param requestHeaders - Incoming request headers containing the session to terminate
+   * @returns Sign-out payload from Better Auth plus response headers to forward (cleared cookies)
+   *
+   * @throws {AuthError} When Better Auth returns an unmapped failure via {@link mapBetterAuthError}
+   *
+   * @remarks
+   * Calls `auth.api.signOut({ headers, returnHeaders: true })`. Forward returned headers
+   * on the HTTP response so session cookies are cleared in the browser. Does not throw
+   * {@link SessionExpiredError} for already-expired sessions unless Better Auth rejects
+   * the sign-out attempt.
+   *
+   * @see {@link credentialsService.login} — counterpart that establishes a session
+   * @see {@link mapBetterAuthError} — converts raw Better Auth errors to domain errors
+   *
+   * @example
+   * ```typescript
+   * const result = await sessionService.logout(request.headers)
+   * return new Response(JSON.stringify(result.data), { headers: result.headers })
+   * ```
+   */
+  async logout(requestHeaders: Headers): Promise<AuthResult<unknown>> {
+    try {
+      const result = await auth.api.signOut({
+        headers: requestHeaders,
+        returnHeaders: true,
+      })
+
+      return {
+        data: result.response,
+        headers: result.headers,
+      }
+    } catch (error) {
+      throw mapBetterAuthError(error)
+    }
+  },
+}

--- a/src/domains/auth/types/index.ts
+++ b/src/domains/auth/types/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Authentication input type exports.
+ *
+ * @module domains/auth/types
+ * @remarks
+ * Re-exports inferred Zod types for authentication request bodies. Provides a stable
+ * import path for services, API routes, and tests without importing schema definitions
+ * directly.
+ *
+ * @see {@link LoginInput} — validated login credentials shape
+ * @see {@link RegisterInput} — validated registration fields shape
+ * @see {@link loginSchema} — source schema for {@link LoginInput}
+ * @see {@link registerSchema} — source schema for {@link RegisterInput}
+ *
+ * @example
+ * ```typescript
+ * import type { LoginInput, RegisterInput } from '@domains/auth/types'
+ *
+ * function handleLogin(input: LoginInput) {
+ *   return credentialsService.login(input, headers)
+ * }
+ * ```
+ */
+
+/**
+ * Validated email/password login request body.
+ *
+ * @remarks
+ * Inferred from {@link loginSchema} as `{ email: string; password: string }`.
+ * Consumed by {@link credentialsService.login} and Better Auth `signInEmail`.
+ *
+ * @see {@link loginSchema}
+ * @see {@link credentialsService.login}
+ *
+ * @example
+ * ```typescript
+ * const input: LoginInput = { email: 'user@example.com', password: 'password123' }
+ * ```
+ */
+export type { LoginInput } from '@domains/auth/schemas'
+
+/**
+ * Validated email/password registration request body.
+ *
+ * @remarks
+ * Inferred from {@link registerSchema} as `{ email: string; password: string; name: string }`.
+ * Consumed by {@link credentialsService.register} and Better Auth `signUpEmail`.
+ *
+ * @see {@link registerSchema}
+ * @see {@link credentialsService.register}
+ *
+ * @example
+ * ```typescript
+ * const input: RegisterInput = {
+ *   email: 'new@example.com',
+ *   password: 'password123',
+ *   name: 'Alice',
+ * }
+ * ```
+ */
+export type { RegisterInput } from '@domains/auth/schemas'

--- a/src/domains/auth/utils/index.ts
+++ b/src/domains/auth/utils/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Authentication utility exports.
+ *
+ * @module domains/auth/utils
+ * @remarks
+ * Helpers for translating Better Auth runtime errors into typed domain errors that
+ * {@link mapErrorToHttp} can map to consistent HTTP responses. Used by
+ * {@link credentialsService} and {@link sessionService} as a shared error boundary.
+ *
+ * @see {@link mapBetterAuthError} — normalizes Better Auth failures to domain errors
+ *
+ * @example
+ * ```typescript
+ * import { mapBetterAuthError } from '@domains/auth/utils'
+ *
+ * try {
+ *   await auth.api.signInEmail({ body, headers })
+ * } catch (error) {
+ *   throw mapBetterAuthError(error)
+ * }
+ * ```
+ */
+
+/** Maps Better Auth errors to typed domain auth errors. */
+export * from './map-better-auth-error-util'

--- a/src/domains/auth/utils/map-better-auth-error-util.ts
+++ b/src/domains/auth/utils/map-better-auth-error-util.ts
@@ -1,0 +1,108 @@
+/**
+ * Maps Better Auth errors to domain-specific auth errors.
+ *
+ * @module domains/auth/utils/map-better-auth-error-util
+ * @remarks
+ * Central error normalization layer between Better Auth server API calls and the
+ * application's {@link AuthError} hierarchy. Inspects lowercased error messages from
+ * Better Auth and returns typed errors suitable for {@link mapErrorToHttp}.
+ *
+ * **Message pattern mapping** (case-insensitive substring match on `error.message`):
+ *
+ * | Pattern | Domain error | Error code | HTTP via {@link mapErrorToHttp} |
+ * |---------|--------------|------------|----------------------------------|
+ * | contains `"invalid"` **and** `"credential"` | {@link InvalidCredentialsError} | `AUTH_INVALID_TOKEN` | **401** Unauthorized |
+ * | contains `"session"` **and** `"expired"` | {@link SessionExpiredError} | `AUTH_SESSION_EXPIRED` | **401** Unauthorized |
+ * | contains `"already exists"` **or** `"duplicate"` | {@link RegistrationFailedError} | `VALIDATION_ERROR` | validation semantic |
+ * | contains `"unauthorized"` **or** `"forbidden"` | {@link AuthError} | `AUTH_FORBIDDEN` | **403** Forbidden |
+ * | non-`Error` value or unmatched `Error` | {@link AuthError} | `AUTH_REQUIRED` | **401** Unauthorized |
+ *
+ * Original Better Auth errors are preserved in `details` on domain error instances
+ * for server-side logging without exposing raw messages to clients.
+ *
+ * @see {@link credentialsService} — login/register error consumer
+ * @see {@link sessionService} — session lookup/logout error consumer
+ * @see {@link mapErrorToHttp} — HTTP status mapping for returned errors
+ */
+import { AuthError } from '@shared/errors/app-error'
+import { ErrorCodes } from '@shared/errors/codes'
+import {
+  InvalidCredentialsError,
+  RegistrationFailedError,
+  SessionExpiredError,
+} from '@domains/auth/errors'
+
+/**
+ * Normalizes Better Auth failures into typed application auth errors.
+ *
+ * @param error - Raw thrown value from Better Auth `signInEmail`, `signUpEmail`,
+ *   `getSession`, or `signOut`
+ * @returns A domain {@link AuthError} subclass (or generic {@link AuthError}) suitable
+ *   for {@link mapErrorToHttp}; never re-throws the original value
+ *
+ * @remarks
+ * **Matching rules** (evaluated only when `error instanceof Error`):
+ * 1. `"invalid"` + `"credential"` → {@link InvalidCredentialsError} with original error in `details`
+ * 2. `"session"` + `"expired"` → {@link SessionExpiredError} with original error in `details`
+ * 3. `"already exists"` or `"duplicate"` → {@link RegistrationFailedError} with Better Auth message
+ * 4. `"unauthorized"` or `"forbidden"` → {@link AuthError} with {@link ErrorCodes.AUTH_FORBIDDEN}
+ * 5. Fallback (non-Error or no pattern match) → {@link AuthError} with
+ *    {@link ErrorCodes.AUTH_REQUIRED} and message `"Authentication failed"`
+ *
+ * @see {@link InvalidCredentialsError}
+ * @see {@link SessionExpiredError}
+ * @see {@link RegistrationFailedError}
+ * @see {@link mapErrorToHttp}
+ *
+ * @example
+ * ```typescript
+ * import { mapBetterAuthError } from '@domains/auth/utils/map-better-auth-error-util'
+ *
+ * try {
+ *   await auth.api.signInEmail({ body, headers })
+ * } catch (error) {
+ *   throw mapBetterAuthError(error) // InvalidCredentialsError for bad password
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Duplicate email during sign-up
+ * mapBetterAuthError(new Error('User already exists'))
+ * // → RegistrationFailedError { code: 'VALIDATION_ERROR', message: 'User already exists' }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Unmatched error
+ * mapBetterAuthError(new Error('Network timeout'))
+ * // → AuthError { code: 'AUTH_REQUIRED', message: 'Authentication failed' }
+ * ```
+ */
+export function mapBetterAuthError(error: unknown): Error {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase()
+
+    if (message.includes('invalid') && message.includes('credential')) {
+      return new InvalidCredentialsError(error)
+    }
+
+    if (message.includes('session') && message.includes('expired')) {
+      return new SessionExpiredError(error)
+    }
+
+    if (message.includes('already exists') || message.includes('duplicate')) {
+      return new RegistrationFailedError(error.message, error)
+    }
+
+    if (message.includes('unauthorized') || message.includes('forbidden')) {
+      return new AuthError(ErrorCodes.AUTH_FORBIDDEN, error.message)
+    }
+  }
+
+  return new AuthError(
+    ErrorCodes.AUTH_REQUIRED,
+    'Authentication failed',
+    error
+  )
+}

--- a/src/pages/api/auth/[...all].ts
+++ b/src/pages/api/auth/[...all].ts
@@ -1,6 +1,0 @@
-import type { APIRoute } from 'astro'
-import { auth } from '@/core/auth/better-auth'
-
-export const ALL: APIRoute = async (ctx) => {
-  return auth.handler(ctx.request)
-}

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -1,0 +1,94 @@
+/**
+ * User login API endpoint.
+ *
+ * @module pages/api/auth/login
+ *
+ * **Route:** `POST /api/auth/login`
+ *
+ * **Authentication:** Public — no session required. Clears any stale session locals
+ * before credential exchange ({@link onRequest} middleware).
+ *
+ * Authenticates a user with email and password via Better Auth, establishes a session,
+ * and returns `Set-Cookie` headers for subsequent authenticated requests.
+ *
+ * @see {@link loginSchema} — request validation schema
+ * @see {@link credentialsService.login} — Better Auth sign-in service
+ * @see {@link mapErrorToHttp} — error-to-HTTP mapping via {@link withErrorHandling}
+ */
+
+import type { APIRoute } from 'astro'
+import { withZodValidation } from '@http/with-validation'
+import { withErrorHandling } from '@http/with-error-handling'
+import { loginSchema } from '@domains/auth/schemas'
+import { credentialsService } from '@domains/auth/services'
+
+/**
+ * Signs in a user with email and password credentials.
+ *
+ * @remarks
+ * **Request**
+ *
+ * | Source | Field | Type | Required | Description |
+ * |--------|-------|------|----------|-------------|
+ * | Body | `email` | `string` | Yes | Valid email address |
+ * | Body | `password` | `string` | Yes | Password (minimum 8 characters) |
+ *
+ * **Success response — `200 OK`**
+ *
+ * ```typescript
+ * {
+ *   data: unknown // Better Auth sign-in payload (user + session)
+ *   status: 200
+ *   meta: {}
+ * }
+ * ```
+ *
+ * Response includes `Set-Cookie` headers forwarded from Better Auth for session persistence.
+ *
+ * **Error responses** (JSON envelope: `{ data: null, status, error, meta }`)
+ *
+ * | Status | Code | When |
+ * |--------|------|------|
+ * | 400 | `VALIDATION_ERROR` | Request body fails {@link loginSchema} validation |
+ * | 401 | `AUTH_INVALID_TOKEN` | Email or password is incorrect |
+ * | 401 | `AUTH_REQUIRED` | Better Auth returns an unmapped authentication failure |
+ * | 401 | `AUTH_SESSION_EXPIRED` | Existing session token is expired during sign-in |
+ * | 403 | `AUTH_FORBIDDEN` | Better Auth rejects the request as unauthorized/forbidden |
+ * | 500 | `DB_ERROR` | Database error during authentication |
+ * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ *
+ * @example
+ * ```bash
+ * curl -X POST "http://localhost:4321/api/auth/login" \
+ *   -H "Content-Type: application/json" \
+ *   -d '{"email":"user@example.com","password":"secret123"}' \
+ *   -c cookies.txt
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const res = await fetch('/api/auth/login', {
+ *   method: 'POST',
+ *   headers: { 'Content-Type': 'application/json' },
+ *   body: JSON.stringify({ email: 'user@example.com', password: 'secret123' }),
+ *   credentials: 'include',
+ * })
+ * const { data, status } = await res.json()
+ * // status: 200, Set-Cookie headers establish session
+ * ```
+ */
+export const POST: APIRoute = withZodValidation(loginSchema)(
+  withErrorHandling(async ({ request, validated }) => {
+    const result = await credentialsService.login(
+      validated.body,
+      request.headers
+    )
+
+    return {
+      data: result.data,
+      status: 200,
+      meta: {},
+      headers: result.headers,
+    }
+  })
+)

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,0 +1,79 @@
+/**
+ * User logout API endpoint.
+ *
+ * @module pages/api/auth/logout
+ *
+ * **Route:** `POST /api/auth/logout`
+ *
+ * **Authentication:** Session recommended — sends session cookies to Better Auth so the
+ * active session can be invalidated. Not listed in {@link publicRoutes}; middleware
+ * resolves session state but does not block unauthenticated callers at the HTTP layer.
+ *
+ * Signs the current user out via Better Auth and returns updated headers that clear
+ * session cookies.
+ *
+ * @see {@link sessionService.logout} — Better Auth sign-out service
+ * @see {@link mapErrorToHttp} — error-to-HTTP mapping via {@link withErrorHandling}
+ */
+
+import type { APIRoute } from 'astro'
+import { withErrorHandling } from '@http/with-error-handling'
+import { sessionService } from '@domains/auth/services'
+
+/**
+ * Ends the current authenticated session and clears session cookies.
+ *
+ * @remarks
+ * **Request**
+ *
+ * No body or query parameters. Forwards the incoming `Cookie` header to Better Auth.
+ *
+ * **Success response — `200 OK`**
+ *
+ * ```typescript
+ * {
+ *   data: unknown // Better Auth sign-out payload
+ *   status: 200
+ *   meta: {}
+ * }
+ * ```
+ *
+ * Response includes updated `Set-Cookie` headers that invalidate the session.
+ *
+ * **Error responses** (JSON envelope: `{ data: null, status, error, meta }`)
+ *
+ * | Status | Code | When |
+ * |--------|------|------|
+ * | 401 | `AUTH_REQUIRED` | No valid session to sign out, or Better Auth auth failure |
+ * | 401 | `AUTH_INVALID_TOKEN` | Session token is invalid |
+ * | 401 | `AUTH_SESSION_EXPIRED` | Session has already expired |
+ * | 403 | `AUTH_FORBIDDEN` | Better Auth rejects the sign-out request |
+ * | 500 | `DB_ERROR` | Database error during sign-out |
+ * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ *
+ * @example
+ * ```bash
+ * curl -X POST "http://localhost:4321/api/auth/logout" \
+ *   -b cookies.txt
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const res = await fetch('/api/auth/logout', {
+ *   method: 'POST',
+ *   credentials: 'include',
+ * })
+ * const { data, status } = await res.json()
+ * // status: 200, session cookies cleared
+ * ```
+ */
+export const POST: APIRoute = withErrorHandling(async ({ request }) => {
+  const result = await sessionService.logout(request.headers)
+
+  return {
+    data: result.data,
+    status: 200,
+    meta: {},
+    headers: result.headers,
+  }
+})

--- a/src/pages/api/auth/register.ts
+++ b/src/pages/api/auth/register.ts
@@ -1,0 +1,97 @@
+/**
+ * User registration API endpoint.
+ *
+ * @module pages/api/auth/register
+ *
+ * **Route:** `POST /api/auth/register`
+ *
+ * **Authentication:** Public — no session required. Clears any stale session locals
+ * before account creation ({@link onRequest} middleware).
+ *
+ * Creates a new user account with email and password via Better Auth, establishes
+ * a session, and returns `Set-Cookie` headers for subsequent authenticated requests.
+ *
+ * @see {@link registerSchema} — request validation schema
+ * @see {@link credentialsService.register} — Better Auth sign-up service
+ * @see {@link mapErrorToHttp} — error-to-HTTP mapping via {@link withErrorHandling}
+ */
+
+import type { APIRoute } from 'astro'
+import { withZodValidation } from '@http/with-validation'
+import { withErrorHandling } from '@http/with-error-handling'
+import { registerSchema } from '@domains/auth/schemas'
+import { credentialsService } from '@domains/auth/services'
+
+/**
+ * Registers a new user account with email, password, and display name.
+ *
+ * @remarks
+ * **Request**
+ *
+ * | Source | Field | Type | Required | Description |
+ * |--------|-------|------|----------|-------------|
+ * | Body | `email` | `string` | Yes | Valid email address |
+ * | Body | `password` | `string` | Yes | Password (minimum 8 characters) |
+ * | Body | `name` | `string` | Yes | Display name (minimum 1 character) |
+ *
+ * **Success response — `201 Created`**
+ *
+ * ```typescript
+ * {
+ *   data: unknown // Better Auth sign-up payload (user + session)
+ *   status: 201
+ *   meta: {}
+ * }
+ * ```
+ *
+ * Response includes `Set-Cookie` headers forwarded from Better Auth for session persistence.
+ *
+ * **Error responses** (JSON envelope: `{ data: null, status, error, meta }`)
+ *
+ * | Status | Code | When |
+ * |--------|------|------|
+ * | 400 | `VALIDATION_ERROR` | Request body fails {@link registerSchema} validation, or account already exists |
+ * | 401 | `AUTH_REQUIRED` | Better Auth returns an unmapped authentication failure |
+ * | 403 | `AUTH_FORBIDDEN` | Better Auth rejects the request as unauthorized/forbidden |
+ * | 500 | `DB_ERROR` | Database error during registration |
+ * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ *
+ * @example
+ * ```bash
+ * curl -X POST "http://localhost:4321/api/auth/register" \
+ *   -H "Content-Type: application/json" \
+ *   -d '{"email":"new@example.com","password":"secret123","name":"New User"}' \
+ *   -c cookies.txt
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const res = await fetch('/api/auth/register', {
+ *   method: 'POST',
+ *   headers: { 'Content-Type': 'application/json' },
+ *   body: JSON.stringify({
+ *     email: 'new@example.com',
+ *     password: 'secret123',
+ *     name: 'New User',
+ *   }),
+ *   credentials: 'include',
+ * })
+ * const { data, status } = await res.json()
+ * // status: 201, Set-Cookie headers establish session
+ * ```
+ */
+export const POST: APIRoute = withZodValidation(registerSchema)(
+  withErrorHandling(async ({ request, validated }) => {
+    const result = await credentialsService.register(
+      validated.body,
+      request.headers
+    )
+
+    return {
+      data: result.data,
+      status: 201,
+      meta: {},
+      headers: result.headers,
+    }
+  })
+)

--- a/src/pages/api/auth/session.ts
+++ b/src/pages/api/auth/session.ts
@@ -1,0 +1,78 @@
+/**
+ * Current session lookup API endpoint.
+ *
+ * @module pages/api/auth/session
+ *
+ * **Route:** `GET /api/auth/session`
+ *
+ * **Authentication:** Session optional — resolves the active session from cookies when
+ * present. Not listed in {@link publicRoutes}; unauthenticated callers receive
+ * `{ user: null, session: null }` rather than a 401.
+ *
+ * Returns the current Better Auth session and user object for client-side auth state.
+ *
+ * @see {@link sessionResponseSchema} — expected session payload shape
+ * @see {@link sessionService.getSession} — Better Auth session lookup service
+ * @see {@link mapErrorToHttp} — error-to-HTTP mapping via {@link withErrorHandling}
+ */
+
+import type { APIRoute } from 'astro'
+import { withErrorHandling } from '@http/with-error-handling'
+import { sessionService } from '@domains/auth/services'
+
+/**
+ * Returns the active session and user from request cookies or headers.
+ *
+ * @remarks
+ * **Request**
+ *
+ * No params, query, or body. Forwards the incoming `Cookie` header to Better Auth.
+ *
+ * **Success response — `200 OK`**
+ *
+ * ```typescript
+ * {
+ *   data: {
+ *     user: { id: string; email: string; name: string } | null
+ *     session: { id: string; userId: string; expiresAt: Date } | null
+ *   }
+ *   status: 200
+ *   meta: {}
+ * }
+ * ```
+ *
+ * When no session cookies are present or the user is unauthenticated, both `user` and
+ * `session` are `null` with status `200`.
+ *
+ * **Error responses** (JSON envelope: `{ data: null, status, error, meta }`)
+ *
+ * | Status | Code | When |
+ * |--------|------|------|
+ * | 401 | `AUTH_SESSION_EXPIRED` | Session token is present but expired |
+ * | 401 | `AUTH_INVALID_TOKEN` | Session token is malformed or invalid |
+ * | 401 | `AUTH_REQUIRED` | Better Auth returns an unmapped authentication failure |
+ * | 403 | `AUTH_FORBIDDEN` | Better Auth rejects the session lookup |
+ * | 500 | `DB_ERROR` | Database error during session resolution |
+ * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ *
+ * @example
+ * ```bash
+ * curl "http://localhost:4321/api/auth/session" -b cookies.txt
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const res = await fetch('/api/auth/session', { credentials: 'include' })
+ * const { data } = await res.json()
+ * // data.user: User | null, data.session: Session | null
+ * ```
+ */
+export const GET: APIRoute = withErrorHandling(async ({ request }) => {
+  const session = await sessionService.getSession(request.headers)
+
+  return {
+    data: session,
+    status: 200,
+    meta: {},
+  }
+})


### PR DESCRIPTION
## Summary
- Add `src/domains/auth/` with credentials, session services, and Better Auth error mapping
- Replace catch-all `/api/auth/[...all]` with explicit login, logout, register, session routes
- Add auth middleware actor resolution

## Test plan
- [ ] Register, login, session, and logout flows work
- [ ] Invalid credentials return 401 with proper error codes