### PR TITLE
chore(cursor): Add commit command and skills lockfile

### DIFF
--- a/.cursor/commands/commit-all.md
+++ b/.cursor/commands/commit-all.md
@@ -1,0 +1,290 @@
+# Git Create Semantic Commits
+
+Create semantic commits from all available changes.
+
+Do not make one big commit by default.
+Group files by purpose.
+Commit each group separately.
+
+## Goal
+
+Turn the current working tree into clean, meaningful commits.
+No guessing. No mega commits. No vague messages. No mixing unrelated changes.
+
+## Steps
+
+### 1. Inspect repository state
+
+Check what changed:
+
+```bash
+git status --short
+```
+
+Check staged changes:
+
+```bash
+git diff --cached
+```
+
+Check unstaged changes:
+
+```bash
+git diff
+```
+
+Check untracked files:
+
+```bash
+git ls-files --others --exclude-standard
+```
+
+Understand every available change before committing.
+
+### 2. Detect issue key
+
+Check branch name and context for an issue key.
+
+```bash
+git branch --show-current
+```
+
+Examples:
+
+- `PROJ-123`
+- `POW-456`
+- `#123`
+
+If there is a clear issue key, use it in every related commit.
+
+If there is no issue key, commit without it.
+
+Do not invent one.
+
+### 3. Group changes semantically
+
+Group files and hunks by intent.
+
+Examples of valid groups:
+
+- one bug fix
+- one feature
+- one refactor
+- one test update
+- one documentation change
+- one dependency update
+- one config or CI change
+
+One commit = one purpose.
+
+If two files changed for the same reason, commit them together.
+
+If one file contains unrelated changes, split hunks.
+
+Use:
+
+```bash
+git add -p
+```
+
+or stage files explicitly:
+
+```bash
+git add <file>
+```
+
+Do not use `git add -A` blindly when changes are unrelated.
+
+### 4. Create commits one by one
+
+For each semantic group:
+
+1. Stage only the files or hunks for that group.
+2. Verify the staged diff.
+3. Create a Conventional Commit message.
+4. Commit.
+5. Repeat until no meaningful changes remain.
+
+Verify staged diff:
+
+```bash
+git diff --cached
+```
+
+Commit format:
+
+```bash
+git commit -m "<type>(<scope>): <summary>"
+```
+
+With issue key:
+
+```bash
+git commit -m "<issue-key>: <type>(<scope>): <summary>"
+```
+
+Examples:
+
+```bash
+git commit -m "fix(auth): Handle expired token refresh"
+git commit -m "feat(api): Add user activity endpoint"
+git commit -m "refactor(ui): Simplify modal state handling"
+git commit -m "test(auth): Cover expired token flow"
+git commit -m "PROJ-123: fix(auth): Handle token refresh"
+```
+
+### 5. Keep committing until done
+
+After each commit, check remaining changes:
+
+```bash
+git status --short
+```
+
+If changes remain, inspect them again and create the next semantic commit.
+
+Stop only when:
+
+- all intentional changes are committed
+- unrelated or unsafe changes are left unstaged on purpose
+- the user must decide what to do with ambiguous changes
+
+## Commit types
+
+Use the most accurate type:
+
+- `feat`: new feature
+- `fix`: bug fix
+- `docs`: documentation only
+- `style`: formatting only, no logic change
+- `refactor`: code change without behavior change
+- `perf`: performance improvement
+- `test`: tests added or updated
+- `build`: build system or dependencies
+- `ci`: CI/CD changes
+- `chore`: maintenance
+- `revert`: revert previous commit
+
+## Scope
+
+Use a short scope when useful:
+
+```bash
+fix(auth): Handle expired session
+feat(payments): Add retry flow
+docs(readme): Update setup instructions
+test(cart): Cover discount calculation
+```
+
+Skip scope only if it adds no value:
+
+```bash
+chore: Update dependencies
+```
+
+Good scopes are usually:
+
+- feature area
+- package name
+- route name
+- module name
+- service name
+- config name
+
+Examples:
+
+```bash
+fix(login): Show invalid credentials error
+feat(dashboard): Add revenue chart
+test(api): Cover pagination params
+ci(github): Cache pnpm dependencies
+build(vite): Update bundle config
+```
+
+## Message rules
+
+- Max 72 characters.
+- Use imperative mood: `Add`, `Fix`, `Update`, `Remove`.
+- Capitalize the summary.
+- No period at the end.
+- Be specific.
+- Describe the purpose, not just the file changed.
+- Do not mention implementation details unless they are the point.
+- Do not say `changes`, `stuff`, `misc`, or `wip`.
+
+Good:
+
+```bash
+git commit -m "fix(auth): Refresh token before request retry"
+git commit -m "feat(profile): Add avatar upload"
+git commit -m "test(cart): Cover discount calculation"
+git commit -m "docs(api): Document pagination params"
+```
+
+Bad:
+
+```bash
+git commit -m "fixed auth"
+git commit -m "updates"
+git commit -m "stuff"
+git commit -m "WIP"
+git commit -m "changed files"
+```
+
+## Splitting rules
+
+Split commits when changes are unrelated.
+
+Examples:
+
+- UI change + dependency update = two commits
+- bug fix + test for that bug = usually one commit
+- refactor + behavior change = two commits
+- docs for a feature + feature code = usually one commit
+- formatting many files + logic change = two commits
+- generated lockfile from dependency update = same commit as dependency update
+
+If a change cannot be explained by the same sentence, split it.
+
+## Safety rules
+
+Never commit:
+
+- secrets
+- `.env` files with real values
+- API keys
+- tokens
+- credentials
+- debug logs
+- local editor files
+- temporary files
+- build artifacts unless intentionally tracked
+- unrelated experiments
+
+Before each commit, check:
+
+```bash
+git diff --cached
+```
+
+If the staged diff contains unrelated changes, unstage and split:
+
+```bash
+git restore --staged <file>
+```
+
+## Final check
+
+When finished, run:
+
+```bash
+git status --short
+```
+
+Then report as less words as possible:
+
+- commits created
+- files intentionally left uncommitted
+- anything skipped for safety
+
+Done means clean semantic history, not just zero pending files.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,92 @@
+{
+  "version": 1,
+  "skills": {
+    "accessibility": {
+      "source": "addyosmani/web-quality-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "bffe3d08cfe92ebad63699f74ce29e35c19850ebfbf474c1463183cfe34d6a09"
+    },
+    "astro": {
+      "source": "astrolicious/agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "2afd3a02edf4374598ce471dabb1ab5638851dbf7b82d0bb36f1019331eafb54"
+    },
+    "best-practices": {
+      "source": "better-auth/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "0d59bc23f61ba03b850aa3b81392044c5c7fa3662a5f61b98490b20b0f14a56a"
+    },
+    "bun": {
+      "source": "midudev/autoskills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "1386ed5490ed278e38312a416c9aa074dbe3849f32ae7f841e4142fef5d4df94"
+    },
+    "clean-code": {
+      "source": "sickn33/antigravity-awesome-skills",
+      "sourceType": "github",
+      "skillPath": "skills/clean-code/SKILL.md",
+      "computedHash": "551e1ac1c416d9df11fce8bc613c3595794f1f5e634d20c5b3e257afded11ed7"
+    },
+    "composition-patterns": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "c124390cc3441844903ada94cb5820b23d922f2d0ad34e01e029e410197c8a32"
+    },
+    "drizzle": {
+      "source": "bobmatnyc/claude-mpm-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "ee38c0b7737febd7409d84e613099a0f276e215e0bbda418b2593786ea8a4754"
+    },
+    "emailAndPassword": {
+      "source": "better-auth/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "1cbc9527756aa933c0f2f5ad7f18fe493f78ef0f4b6f073b624fbf6ccbd463c9"
+    },
+    "frontend-design": {
+      "source": "anthropics/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "82fb11a63fb1e35ee2469516ed02d54695f783115b1540c0e783197af4240a3a"
+    },
+    "jsdoc-typescript-docs": {
+      "source": "patricio0312rev/skills",
+      "sourceType": "github",
+      "skillPath": "foundation/jsdoc-typescript-docs/SKILL.md",
+      "computedHash": "96505a4a52e2cc4b14c942b6a8df66352c960cb5b3c27a26d45e0ea461910e14"
+    },
+    "organization": {
+      "source": "better-auth/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "74bd4e58dd4b66466f79cf0d00a5e75d5ca81b98c0461ee8cd7faba7d8dc16fa"
+    },
+    "react-best-practices": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "502eb06700e2c3cb1bd7f710860528f72281320bd5171a2087b05a090b573dc1"
+    },
+    "seo": {
+      "source": "addyosmani/web-quality-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "c184da724d1c61ad077f27418ea8e7e88fd54bcdf98165e18be7e4681cbd5e20"
+    },
+    "tailwind-css-patterns": {
+      "source": "giuseppe-trisciuoglio/developer-kit",
+      "sourceType": "autoskills-registry",
+      "computedHash": "8fd534b64b3f305ade80c207e2f9ba4338d5e409e355af9f724c36764b6709c1"
+    },
+    "twoFactor": {
+      "source": "better-auth/skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "85230144b20eed676d0cbe8d28997cb9ccc0b293517204215adad0d74fae9a9d"
+    },
+    "typescript-advanced-types": {
+      "source": "wshobson/agents",
+      "sourceType": "autoskills-registry",
+      "computedHash": "5ca0e177c6aaaba1889255691224daafdb7d71f317cc70bede1590d3907ded42"
+    },
+    "zod": {
+      "source": "pproenca/dot-skills",
+      "sourceType": "autoskills-registry",
+      "computedHash": "aa8a97195b07763d37494b511f48be90979fd6826c031956c831cfc58f6a24b8"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.cursor/commands/commit-all.md` for semantic commit workflow
- Add `skills-lock.json` pinning agent skill sources

## Test plan
- [ ] Cursor command loads correctly
- [ ] Skills lockfile matches installed skills