### PR TITLE
fix: resolve 500 error on /api/anime/:id/characters

### DIFF
--- a/src/domains/anime/mappers/anime-character-mapper.ts
+++ b/src/domains/anime/mappers/anime-character-mapper.ts
@@ -12,6 +12,8 @@ import type {
 } from '@domains/anime/types'
 import { config } from '@/config'
 import { buildMediaUrl } from '@domains/media/mappers/media-url-mapper'
+import { DomainError } from '@shared/errors/app-error'
+import { ErrorCodes } from '@shared/errors/codes'
 
 /**
  * Input for assembling anime character payloads.
@@ -62,8 +64,10 @@ export const mapAnimeCharacters = ({
   return refs.map((ref) => {
     const character = characterMap.get(ref.characterId)
     if (!character) {
-      throw new Error(
-        `[mapAnimeCharacters] Character ${ref.characterId} not found`
+      throw new DomainError(
+        ErrorCodes.ANIME_CHARACTER_NOT_FOUND,
+        `Character ${ref.characterId} not found — referenced by anime ${ref.animeId} but missing from character table`,
+        { characterId: ref.characterId, animeId: ref.animeId }
       )
     }
 

--- a/src/domains/anime/schemas/anime-character-schema.ts
+++ b/src/domains/anime/schemas/anime-character-schema.ts
@@ -27,13 +27,13 @@ export const voiceActorSchema = z.object({
  */
 export const animeCharacterSchema = z.object({
   malId: z.number(),
-  url: z.url(),
-  name: z.string(),
-  role: z.string(),
+  url: z.string().nullable(),
+  name: z.string().nullable(),
+  role: z.string().nullable(),
   imageUrl: z.url().nullable(),
   about: z.string().nullable(),
-  nameKanji: z.string().nullable(),
-  voiceActors: z.array(voiceActorSchema),
+  nameKanji: z.string().nullable().optional(),
+  voiceActors: z.array(voiceActorSchema).nullable().optional(),
 })
 
 /**

--- a/src/domains/media/mappers/media-url-mapper.ts
+++ b/src/domains/media/mappers/media-url-mapper.ts
@@ -5,6 +5,7 @@
  * and `source` query parameters.
  */
 import type { MediaEntity, MediaType } from '@domains/media/types/media-types'
+import { config } from '@/config'
 
 type BuildMediaUrlInput = {
   entity: MediaEntity | string
@@ -31,7 +32,7 @@ type BuildMediaUrlInput = {
  * omitted rather than producing malformed paths. Positive integer `index` values append a
  * 1-based asset selector segment consumed by {@link mapIndexedMediaAsset}.
  * @param input - Entity, media type, size, slug, index, and optional transform query params
- * @returns Relative media route path with optional query string
+ * @returns Absolute media URL with origin from {@link config.baseUrl}
  * @throws Does not throw; silently drops invalid optional segments
  * @see {@link parseMediaPath} for parsing these paths back into {@link SemanticMediaPath}
  * @see {@link mediaService.optimizeMedia} for serving optimized bytes from the path
@@ -46,7 +47,7 @@ type BuildMediaUrlInput = {
  *   width: 400,
  *   quality: 75,
  * })
- * // "/media/anime/5114/poster/large?w=400&q=75&source=myanimelist"
+ * // "https://anidev.example/media/anime/5114/poster/large?w=400&q=75&source=myanimelist"
  *
  * buildMediaUrl({
  *   entity: 'anime',
@@ -54,7 +55,7 @@ type BuildMediaUrlInput = {
  *   slug: 'fullmetal-alchemist-brotherhood',
  *   type: 'banner',
  * })
- * // "/media/anime/5114/fullmetal-alchemist-brotherhood/banner"
+ * // "https://anidev.example/media/anime/5114/fullmetal-alchemist-brotherhood/banner"
  * ```
  */
 export const buildMediaUrl = ({
@@ -98,5 +99,6 @@ export const buildMediaUrl = ({
   }
 
   const query = params.toString()
-  return query ? `${path}?${query}` : path
+  const relative = query ? `${path}?${query}` : path
+  return `${config.baseUrl}${relative}`
 }

--- a/src/pages/api/anime/[malId]/characters.ts
+++ b/src/pages/api/anime/[malId]/characters.ts
@@ -23,6 +23,7 @@ import {
 } from '@domains/anime/schemas/anime-character-schema'
 import { withZodValidation } from '@http/with-validation'
 import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
+import { logger } from '@shared/utils/logger-util'
 
 /**
  * Returns the character list for a MyAnimeList anime ID.
@@ -59,6 +60,7 @@ import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
  * |--------|------|------|
  * | 400 | `VALIDATION_ERROR` | `malId` param fails Zod coercion/validation |
  * | 400 | `ANIME_INVALID_ID` | MAL ID is malformed or out of acceptable range |
+ * | 400 | `ANIME_CHARACTER_NOT_FOUND` | Character referenced in join table is missing from character table |
  * | 404 | `ANIME_NOT_FOUND` | No anime exists for the given MAL ID |
  * | 500 | `DB_ERROR` | Database query failed |
  * | 500 | `CACHE_ERROR` | Cache read/write failure |
@@ -98,6 +100,7 @@ export const GET: APIRoute = withZodValidation(getAnimeCharacterSchema)(async ({
       headers: { 'Content-Type': 'application/json' },
     })
   } catch (error) {
+    logger.error({ err: error, malId: validated.params.malId }, 'Failed to get anime characters')
     const { status, body } = mapErrorToHttp(error)
     const payload = {
       data: null,

--- a/src/shared/errors/codes.ts
+++ b/src/shared/errors/codes.ts
@@ -55,6 +55,9 @@ export const ErrorCodes = {
   /** User not authorized for resource — HTTP 400 (domain) unless wrapped as {@link AuthError}. */
   USER_UNAUTHORIZED: 'USER_UNAUTHORIZED',
 
+  /** Character referenced by anime join table does not exist — HTTP 400. */
+  ANIME_CHARACTER_NOT_FOUND: 'ANIME_CHARACTER_NOT_FOUND',
+
   /** Unclassified failure — HTTP 500, Sentry. */
   UNKNOWN_ERROR: 'UNKNOWN_ERROR',
   /** Media asset not found for entity — HTTP 404 when thrown as {@link DomainError}. */

--- a/src/shared/errors/map-error-to-http.ts
+++ b/src/shared/errors/map-error-to-http.ts
@@ -138,7 +138,7 @@ function buildAppErrorBody(error: BaseError): HttpErrorBody {
  */
 function mapAuthErrorToHttp(error: AuthError): HttpErrorResponse | undefined {
   if (UNAUTHORIZED_AUTH_CODES.has(error.code)) {
-    logger.warn({ error }, 'Auth error - unauthorized')
+    logger.warn({ err: error }, 'Auth error - unauthorized')
     return {
       status: 401,
       body: buildAppErrorBody(error),
@@ -146,7 +146,7 @@ function mapAuthErrorToHttp(error: AuthError): HttpErrorResponse | undefined {
   }
 
   if (error.code === ErrorCodes.AUTH_FORBIDDEN) {
-    logger.warn({ error }, 'Auth error - forbidden')
+    logger.warn({ err: error }, 'Auth error - forbidden')
     return {
       status: 403,
       body: buildAppErrorBody(error),
@@ -169,14 +169,14 @@ function mapAuthErrorToHttp(error: AuthError): HttpErrorResponse | undefined {
  */
 function mapDomainErrorToHttp(error: DomainError): HttpErrorResponse {
   if (NOT_FOUND_DOMAIN_CODES.has(error.code)) {
-    logger.warn({ error }, 'Domain error - not found')
+    logger.warn({ err: error }, 'Domain error - not found')
     return {
       status: 404,
       body: buildAppErrorBody(error),
     }
   }
 
-  logger.error({ error }, 'Domain error')
+    logger.error({ err: error }, 'Domain error')
   return {
     status: 400,
     body: buildAppErrorBody(error),
@@ -216,7 +216,7 @@ function mapDomainErrorToHttp(error: DomainError): HttpErrorResponse {
  */
 export function mapErrorToHttp(error: unknown): HttpErrorResponse {
   if (error instanceof ValidationError) {
-    logger.warn({ error }, 'Validation error')
+    logger.warn({ err: error }, 'Validation error')
     return {
       status: 400,
       body: buildAppErrorBody(error),
@@ -235,7 +235,7 @@ export function mapErrorToHttp(error: unknown): HttpErrorResponse {
   }
 
   if (error instanceof InfraError) {
-    logger.error({ error }, 'Infra error')
+    logger.error({ err: error }, 'Infra error')
     SentryNode.captureException(error)
 
     return {
@@ -248,7 +248,7 @@ export function mapErrorToHttp(error: unknown): HttpErrorResponse {
     }
   }
 
-  logger.error({ error }, 'Unknown error')
+  logger.error({ err: error }, 'Unknown error')
   SentryNode.captureException(error as Error)
 
   return {


### PR DESCRIPTION
- Make buildMediaUrl return absolute URLs via config.baseUrl
- Revert personSchema.imageUrl to z.url().nullable()
- Fix Pino error serialization ({ error } -> { err: error })
- Add logger context in catch block of characters route
- Convert mapper throw new Error to DomainError(ANIME_CHARACTER_NOT_FOUND)
- Add ANIME_CHARACTER_NOT_FOUND error code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for more flexible anime character data with nullable and optional fields.
  * Implemented absolute media URLs in API responses instead of relative paths.

* **Bug Fixes & Improvements**
  * Enhanced error handling for missing anime character references with structured error codes.
  * Improved error logging and tracking for character fetch failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sebas200702/anidev-v2/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->