### PR TITLE
fix(media): Update caching logic to handle placeholder images correctly

### DIFF
--- a/src/domains/media/services/media-service.ts
+++ b/src/domains/media/services/media-service.ts
@@ -162,6 +162,7 @@ export const mediaService = {
 
     const normalizedOptions = normalizeOptimizeOptions(options)
     const resolvedParams = params
+    let isPlaceholder = false
 
     return withCache({
       key: mediaCache.key(resolvedParams, normalizedOptions),
@@ -173,9 +174,11 @@ export const mediaService = {
           resolvedParams,
           normalizedOptions.source
         )
+        isPlaceholder = media.src === mediaServiceConfig.defaultPlaceholderUrl
         const buffer = await this.fetchImageBuffer(media.src)
         return optimizeMediaImageBuffer(buffer, normalizedOptions)
       },
+      shouldCache: () => !isPlaceholder,
     })
   },
 


### PR DESCRIPTION
This pull request updates the `mediaService` in `media-service.ts` to improve how image placeholders are handled and cached. The main change is to prevent caching of placeholder images by detecting when the default placeholder is used and conditionally disabling the cache.

Caching improvements for placeholder images:

* Added logic to detect if the fetched image source is the default placeholder URL by comparing `media.src` to `mediaServiceConfig.defaultPlaceholderUrl`, and set the `isPlaceholder` flag accordingly.
* Updated the cache configuration to include a `shouldCache` function that disables caching when the image is a placeholder (`!isPlaceholder`).
* Introduced the `isPlaceholder` variable to track whether the current image is a placeholder.