### PR TITLE
feat(anime): Enhance media handling in anime mapping

### DIFF
--- a/src/domains/anime/mappers/anime-full-mapper.ts
+++ b/src/domains/anime/mappers/anime-full-mapper.ts
@@ -15,10 +15,12 @@ import type {
   GenreDB,
   ThemeDB,
 } from '@domains/anime/types'
-import type { MusicDB } from '@domains/music/types/music-db-types'
+import type { MusicDB } from '@domains/music/types'
 import { mapMusicListToAnimeMusic } from '@domains/anime/mappers/anime-music-mapper'
 import { mapExternalIds } from '@domains/anime/mappers/anime-external-mapper'
 import { config } from '@/config'
+import { buildMediaUrl } from '@domains/media/mappers/media-url-mapper'
+import { detectMediaSource } from '@domains/media/mappers/media-assets-mapper'
 import type { MediaAsset } from '@domains/media/types/media-types'
 
 /** Grouped relation entry used while building full detail payloads. */
@@ -130,6 +132,24 @@ export function mapAnimeToFullDetails({
     }, {})
   )
 
+  const mediaGroups = new Map<string, MediaAsset[]>()
+  for (const asset of media) {
+    const key = `${asset.mediaType}:${asset.size ?? 'default'}`
+    const group = mediaGroups.get(key)
+    if (group) {
+      group.push(asset)
+    } else {
+      mediaGroups.set(key, [asset])
+    }
+  }
+
+  const assetIndices = new Map<number, number>()
+  for (const [, group] of mediaGroups) {
+    group.forEach((asset, idx) => {
+      assetIndices.set(asset.id, idx + 1)
+    })
+  }
+
   const external: AnimeExternalIds[] = mapExternalIds(externalIds)
 
   return {
@@ -150,7 +170,14 @@ export function mapAnimeToFullDetails({
     synopsis: anime.synopsis ?? 'No synopsis available.',
     media: media.map((m) => ({
       mediaType: m.mediaType,
-      src: m.src,
+      src: buildMediaUrl({
+        entity: 'anime',
+        entity_id: anime.malId,
+        type: m.mediaType,
+        size: (m.size ?? 'default') as 'default' | 'small' | 'large',
+        index: assetIndices.get(m.id) ?? 1,
+        source: detectMediaSource(m.src),
+      }),
       size: m.size ?? 'default',
     })),
     relations: relationsGrouped,

--- a/src/domains/media/mappers/media-assets-mapper.ts
+++ b/src/domains/media/mappers/media-assets-mapper.ts
@@ -25,7 +25,7 @@ type MediaSource = NonNullable<OptimizeOptions['source']>
  * // "myanimelist"
  * ```
  */
-const detectMediaSource = (src: string): MediaSource => {
+export const detectMediaSource = (src: string): MediaSource => {
   try {
     const host = new URL(src).hostname.toLowerCase()
 
@@ -43,6 +43,10 @@ const detectMediaSource = (src: string): MediaSource => {
 
     if (host.includes('thetvdb')) {
       return 'thetvdb'
+    }
+
+    if (host.includes('tmdb') || host.includes('themoviedb')) {
+      return 'tmdb'
     }
 
     if (host.includes('youtube')) {

--- a/src/domains/media/mappers/media-url-mapper.ts
+++ b/src/domains/media/mappers/media-url-mapper.ts
@@ -21,6 +21,7 @@ type BuildMediaUrlInput = {
     | 'anilist'
     | 'kitsu'
     | 'thetvdb'
+    | 'tmdb'
     | 'custom'
     | 'youtube'
 }

--- a/src/domains/media/repositories/anime-media-repository.ts
+++ b/src/domains/media/repositories/anime-media-repository.ts
@@ -47,6 +47,7 @@ export const animeMediaRepository = {
         .select()
         .from(animeMedia)
         .where(eq(animeMedia.animeId, animeId))
+        .orderBy(asc(animeMedia.id))
     } catch (error) {
       throw dbError('[GET_MEDIA_BY_ANIME_ID]', { animeId }, error)
     }

--- a/src/shared/utils/image/optimize-util.ts
+++ b/src/shared/utils/image/optimize-util.ts
@@ -25,6 +25,7 @@ export type ImageSource =
   | 'anilist'
   | 'kitsu'
   | 'thetvdb'
+  | 'tmdb'
   | 'custom'
   | 'youtube'
 


### PR DESCRIPTION
- Introduced media grouping and indexing in `mapAnimeToFullDetails` for better organization of media assets.
- Updated `buildMediaUrl` to utilize new media source detection logic.
- Exported `detectMediaSource` function for broader usage.
- Added 'tmdb' as a recognized media source in relevant mappers and types.
- Ensured media assets are ordered by ID in the anime media repository.