### PR TITLE
Refactor/lib cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# AniDev v2 — Agent Guide
+
+## Stack
+- **Runtime**: Bun (primary), Node.js >=22.12.0
+- **Framework**: Astro 6 SSR with `@astrojs/vercel` adapter (`output: 'server'`)
+- **Database**: Turso (LibSQL) via `@libsql/client` + Drizzle ORM
+- **Cache**: Upstash Redis (REST API)
+- **Auth**: Better Auth 1.5.5 (email/password, Drizzle SQLite adapter)
+- **Styling**: Tailwind CSS v4 (`@tailwindcss/vite` plugin)
+- **Monitoring**: Sentry (server + Astro + React; no-ops when `SENTRY_DSN` unset)
+
+## Commands
+| Script | Purpose |
+|--------|---------|
+| `bun run dev` | Astro dev server |
+| `bun run build` | Production build (Vercel output) |
+| `bun run format` | Prettier (semi:false, singleQuote, trailingComma:es5) |
+| `bun run auth:generate` | Generate Better Auth schema (config: `src/lib/auth/server.ts`) |
+| `bun run auth:migrate` | Run Better Auth migrations |
+| `bun run db:generate` | Drizzle migration generation |
+| `bun run db:migrate` | Apply Drizzle migrations |
+| `bun run astro sync` | Regenerate `.astro/types.d.ts` (gitignored, needed after schema changes) |
+| `bun run release:*` | `standard-version` (patch/minor/major/prerelease) |
+
+No test, lint, or typecheck scripts exist. No CI workflows found.
+
+## Architecture (Domain-Driven + Presentational-Container)
+
+### Layered structure
+```
+src/config/     → env validation (Zod, eager at import), site config, public routes
+src/lib/        → infrastructure: auth, db, cache, monitoring
+src/domains/    → business slices: anime/ auth/ media/ music/ user/
+src/pages/      → Astro pages + API routes (file-based routing)
+src/middleware/  → session middleware (auth-middleware.ts, registered in astro.config.mjs)
+src/shared/     → cross-cutting: http/ errors/ schemas/ layouts/ components/ utils/
+```
+
+### Data flow
+```
+DB schema (lib/db/schemas/) → Repository → Mapper → Service → Page/API route
+```
+
+### Presentational-Container pattern
+- **Containers** = Astro page routes (`src/pages/`): fetch data from services, handle errors/redirects, pass data down
+- **Presentational** = Astro SFCs in `src/domains/*/components/`: receive props only, render markup, zero data-fetching
+- **Rule**: *"Data is supplied by domain services in page routes, not fetched inside components"*
+- Each component lives in its own directory: `Name/Name.astro` + `index.ts` barrel
+
+### Domain vertical slice
+Each domain has: `cache/ components/ errors/ mappers/ repositories/ schemas/ services/ types/` (optional: `middleware/`, `policies/`, `utils/`, `config.ts`)
+
+Strict barrel exports at every level.
+
+### Max file size
+**≤150 lines per file.** 17 files currently exceed this (primarily `media/`, `shared/errors/`, and DB schemas) — refactor when touching.
+
+## Path Aliases (tsconfig + Vite)
+`@`, `@styles`, `@domains`, `@shared`, `@lib`, `@config`, `@middleware`, `@layouts`, `@http`, `@components`, `@hooks`, `@stores`, `@utils`, `@db` — all map to `src/` subdirectories. Use these instead of relative imports.
+
+## API Route Patterns
+Two composition styles:
+1. `withZodValidation(schema)(handler)` — validates `{ params, query, body }` as single Zod object, returns 400 on failure
+2. Error handling: `withErrorHandling(handler)` (try/catch wrapper) OR manual try/catch + `mapErrorToHttp(error)`
+
+Response envelope: `{ data, status, error?, meta? }`. Error codes in `src/shared/errors/codes.ts`. HTTP mapping in `src/shared/errors/map-error-to-http.ts`.
+
+## Auth & Middleware
+- **Public routes** (prefix-matched): `/`, `/api/auth/login`, `/api/auth/register`, `/api/anime`, `/api/music`, `/media`
+- Middleware populates `locals.user` / `locals.session` via `resolveAuthActor()` (swallows errors, returns null)
+- For strict auth in API routes: `sessionService.getSession()` throws typed errors
+
+## Environment
+- Validated eagerly at import via Zod in `src/config/env.ts` — missing required vars = immediate crash
+- **Required**: `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`, `BETTER_AUTH_SECRET` (≥32 chars), `BETTER_AUTH_URL`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
+- `APP_BASE_URL` optional, falls back to `BETTER_AUTH_URL`
+
+## Skills & Key Guidelines
+
+| Skill | Key rules for this repo |
+|-------|------------------------|
+| **Clean Code** | Small functions (≤1 screen), single responsibility, meaningful names, no side effects, no boolean params in signatures |
+| **Composition Patterns** | Avoid boolean prop proliferation → compound components; prefer `children` over render props |
+| **React Best Practices** | No barrel imports from large modules; `Promise.all()` for parallel fetches; Suspense boundaries; hoist static I/O; minimize serialization; `React.cache()` for data |
+| **Zod** | `safeParse()` for user input; `z.infer` for type inference; `z.unknown()` not `z.any()`; validate at boundary; `strict()` for incoming data |
+| **Drizzle ORM** | Schema-first with `$inferSelect`/`$inferInsert`; drizzle-kit for migrations; relations for joins |
+| **Better Auth** | Config: `src/lib/auth/server.ts`; client: `authClient` from `src/lib/auth/client.ts`; email/password only |
+| **Tailwind CSS** | Mobile-first; compose utilities over `@apply`; extract repeating patterns as components; CSS variables for themes |
+| **TypeScript** | `z.infer` over manual types; branded types for IDs; discriminated unions for states; `unknown` over `any` |
+| **JSDoc** | Follow existing style (`@module`, `@remarks`, `@see`, `@example`, `@throws`) — codebase is heavily documented |
+| **Frontend Design** | Avoid generic AI aesthetics (no Inter/Roboto, no purple gradients); distinctive typography, asymmetric layouts, CSS variables |
+| **Accessibility** | Semantic HTML, ARIA labels, focus management, skip links, color contrast ≥4.5:1, prefers-reduced-motion |
+| **SEO** | Structured JSON-LD data, OG tags in `base-layout.astro`, canonical URLs, meta descriptions |
+| **Core Web Vitals** | Preload LCP image; `aspect-ratio` for CLS; no tasks >50ms for INP; `font-display: optional` |
+| **Astro** | `astro:middleware` for session; `src/pages/` file-based routing; adapter configures output target |
+
+## Prettier Config
+No semicolons, single quotes, trailing commas es5, 80 print width, arrow parens always. Plugins: `prettier-plugin-astro`, `prettier-plugin-tailwindcss`.
+
+## Important Constraints
+- Better Auth CLI commands are preconfigured with `--config src/lib/auth/server.ts` — do not change path
+- Cache TTL values in **seconds** (`CacheTtl` enum in `src/lib/cache/config.ts`)
+- No `.tsx` React components exist yet (React is configured but unused)
+- No `drizzle.config` found — may need creation for migration generation
+- Auth middleware uses cookie markers (`session_token=`, `session_data=`) — do not rename without updating middleware
+- Sentry no-ops when `SENTRY_DSN` is absent — safe to call `init*` unconditionally
+
+## Commit Convention
+Conventional commits with scopes: `type(scope): summary` (e.g., `fix(auth): Handle expired token`). See `.cursor/commands/commit-all.md`.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -58,6 +58,12 @@
       "sourceType": "autoskills-registry",
       "computedHash": "74bd4e58dd4b66466f79cf0d00a5e75d5ca81b98c0461ee8cd7faba7d8dc16fa"
     },
+    "presentational-container-pattern": {
+      "source": "patternsdev/skills",
+      "sourceType": "github",
+      "skillPath": "react/presentational-container-pattern/SKILL.md",
+      "computedHash": "4ced40006fc1d604be8fd3c321e50a71c86867b7fd7c25378027c909b5b7bdbe"
+    },
     "react-best-practices": {
       "source": "vercel-labs/agent-skills",
       "sourceType": "autoskills-registry",

--- a/src/domains/music/cache/index.ts
+++ b/src/domains/music/cache/index.ts
@@ -14,3 +14,4 @@
  * ```
  */
 export * from './music-cache'
+export * from './music-list-cache'

--- a/src/domains/music/cache/music-list-cache.ts
+++ b/src/domains/music/cache/music-list-cache.ts
@@ -1,0 +1,82 @@
+/**
+ * Cache helpers for paginated music list responses.
+ *
+ * @module domains/music/cache/music-list-cache
+ * @remarks
+ * Read-through cache for filtered list results from
+ * {@link musicListService.getMusicList}. Key includes the full normalized filter
+ * object (pagination + facets) via `JSON.stringify`.
+ *
+ * **Key format:** `music:list:{JSON.stringify(filters)}`
+ *
+ * **TTL:** `CacheTtl.Medium` (3600 s) — list pages are filter-sensitive; one hour
+ * limits stale pagination totals while avoiding repeated list queries.
+ *
+ * **Null vs miss:** `null` triggers list + count queries; cached value holds
+ * `{ list, total }` even when `list` is empty.
+ *
+ * @see {@link musicListService}
+ * @see {@link mapMusicListFilters}
+ */
+import { cacheGet, cacheSet } from '@lib/cache'
+import { CacheKeyPrefix, CacheTtl } from '@lib/cache/config'
+import type { MusicCard, MusicListFilters } from '@domains/music/types'
+
+/**
+ * Cached payload for a filtered music list query.
+ *
+ * @remarks
+ * Mirrors the return shape of {@link musicListService.getMusicList}.
+ */
+type MusicListCacheValue = {
+  /** Mapped card rows for the current page */
+  list: MusicCard[]
+  /** Total rows matching filters (all pages) */
+  total: number
+}
+
+/**
+ * Read-through cache for paginated music list results keyed by filter set.
+ */
+export const musicListCache = {
+  /**
+   * Builds the Redis cache key for a music list query.
+   *
+   * @param filters - Normalized {@link MusicListFilters}
+   * @returns `music:list:` + stable JSON of filters (property order matters)
+   *
+   * @example
+   * ```typescript
+   * musicListCache.key({ page: 1, limit: 10, type: 'OP' })
+   * // 'music:list:{"page":1,"limit":10,"type":"OP"}'
+   * ```
+   */
+  key(filters: MusicListFilters) {
+    return `${CacheKeyPrefix.MusicList}:${JSON.stringify(filters)}`
+  },
+
+  /**
+   * Retrieves a cached music list result.
+   *
+   * @param filters - Same normalized filters used for `key`
+   * @returns `{ list, total }` on hit, `null` on miss
+   */
+  async get(filters: MusicListFilters): Promise<MusicListCacheValue | null> {
+    return cacheGet<MusicListCacheValue>(this.key(filters))
+  },
+
+  /**
+   * Stores a paginated music list result in Redis.
+   *
+   * @param filters - Normalized filters
+   * @param value - Cards for current page and total count
+   */
+  async set(
+    filters: MusicListFilters,
+    value: MusicListCacheValue
+  ): Promise<void> {
+    return cacheSet<MusicListCacheValue>(this.key(filters), value, {
+      ttlSeconds: CacheTtl.Medium,
+    })
+  },
+}

--- a/src/domains/music/mappers/index.ts
+++ b/src/domains/music/mappers/index.ts
@@ -8,4 +8,6 @@
  * import { mapMusicDetail } from '@domains/music/mappers'
  * ```
  */
+export * from './music-card-mapper'
 export * from './music-detail-mapper'
+export * from './music-filters-mapper'

--- a/src/domains/music/mappers/music-card-mapper.ts
+++ b/src/domains/music/mappers/music-card-mapper.ts
@@ -1,0 +1,76 @@
+/**
+ * Maps database music rows into card payloads for list views.
+ *
+ * @module domains/music/mappers/music-card-mapper
+ */
+import type { MusicDB, MusicArtistDB } from '@domains/music/types/music-db.d-types'
+import type { MusicCard } from '@domains/music/types/music-card.d-types'
+
+/** Input for mapping a single music row to a card. */
+type MapMusicCardInput = {
+  music: MusicDB
+  artists: MusicArtistDB[]
+}
+
+/** Input for mapping multiple music rows to cards. */
+type MapMusicListToCardsInput = {
+  musicList: MusicDB[]
+  artistsByMusicId: Record<number, MusicArtistDB[]>
+}
+
+/**
+ * Maps a single music database row into a {@link MusicCard}.
+ *
+ * @param input - Music row plus linked artists
+ * @returns Compact card with type labels and artist credits
+ *
+ * @remarks
+ * - `type` / `typeCode` normalize DB codes (`OP`, `ED`, `UNK`)
+ * - Missing titles default to `'Unknown Title'`
+ *
+ * @see {@link musicCardSchema}
+ */
+export const mapMusicCard = ({
+  music,
+  artists,
+}: MapMusicCardInput): MusicCard => {
+  const typeCode: MusicCard['typeCode'] =
+    music.type === 'OP' || music.type === 'ED' || music.type === 'UNK'
+      ? music.type
+      : 'UNK'
+
+  let type: MusicCard['type'] = 'unknown'
+  if (typeCode === 'OP') type = 'opening'
+  else if (typeCode === 'ED') type = 'ending'
+
+  return {
+    id: music.id,
+    title: music.title ?? 'Unknown Title',
+    type,
+    typeCode,
+    artists: artists.map((a) => ({
+      name: a.name ?? 'Unknown Artist',
+      malId: a.malId ?? 0,
+    })),
+  }
+}
+
+/**
+ * Maps a collection of music rows into card payloads.
+ *
+ * @param input - Music rows for one list page and artists grouped by music ID
+ * @returns {@link MusicCard}[] in repository order
+ *
+ * @see {@link musicListService}
+ */
+export const mapMusicListToCards = ({
+  musicList,
+  artistsByMusicId,
+}: MapMusicListToCardsInput): MusicCard[] => {
+  return musicList.map((music) =>
+    mapMusicCard({
+      music,
+      artists: artistsByMusicId[music.id] ?? [],
+    })
+  )
+}

--- a/src/domains/music/mappers/music-filters-mapper.ts
+++ b/src/domains/music/mappers/music-filters-mapper.ts
@@ -1,0 +1,72 @@
+/**
+ * Maps raw list query parameters into normalized filter objects.
+ *
+ * @module domains/music/mappers/music-filters-mapper
+ */
+import type {
+  MusicListFilters,
+  MusicListFiltersParams,
+} from '@domains/music/types'
+
+const TYPE_CODE_BY_LABEL: Record<string, MusicListFilters['type']> = {
+  opening: 'OP',
+  ending: 'ED',
+  unknown: 'UNK',
+  op: 'OP',
+  ed: 'ED',
+  unk: 'UNK',
+  OP: 'OP',
+  ED: 'ED',
+  UNK: 'UNK',
+}
+
+/**
+ * Coerces a raw type query value to a database type code.
+ *
+ * @internal
+ */
+const normalizeType = (
+  raw?: string
+): MusicListFilters['type'] | undefined => {
+  const trimmed = raw?.trim()
+  if (!trimmed) return undefined
+
+  const fromMap =
+    TYPE_CODE_BY_LABEL[trimmed] ?? TYPE_CODE_BY_LABEL[trimmed.toLowerCase()]
+  if (fromMap) return fromMap
+
+  if (trimmed === 'OP' || trimmed === 'ED' || trimmed === 'UNK') {
+    return trimmed
+  }
+
+  return undefined
+}
+
+/**
+ * Normalizes request query parameters into repository-ready filters.
+ *
+ * @param params - Raw query from {@link musicListFiltersParamsSchema}
+ * @returns {@link MusicListFilters} with DB `type` codes when a type filter is present
+ *
+ * @remarks
+ * Used by {@link musicListService} for repository queries and
+ * {@link musicListCache.key} (must stay stable for cache hits).
+ *
+ * @example
+ * ```typescript
+ * mapMusicListFilters({ page: 1, limit: 10, type: 'opening' })
+ * // { page: 1, limit: 10, type: 'OP', ... }
+ * ```
+ *
+ * @see {@link buildMusicListFilters}
+ */
+export const mapMusicListFilters = (
+  params: MusicListFiltersParams
+): MusicListFilters => {
+  return {
+    page: params.page,
+    limit: params.limit,
+    type: normalizeType(params.type),
+    query: params.query?.trim() || undefined,
+  }
+}

--- a/src/domains/music/repositories/index.ts
+++ b/src/domains/music/repositories/index.ts
@@ -10,6 +10,7 @@
  * ```
  */
 export * from './anime-music-repository'
+export * from './music-list-repository'
 export * from './music-relation-repository'
 export * from './music-repository'
 export * from './music-version-repository'

--- a/src/domains/music/repositories/music-list-repository.ts
+++ b/src/domains/music/repositories/music-list-repository.ts
@@ -1,0 +1,134 @@
+/**
+ * Data access and filter builders for paginated music list queries.
+ *
+ * @module domains/music/repositories/music-list-repository
+ */
+import { db } from '@db/client'
+import { music } from '@db/schemas/music'
+import { dbError } from '@shared/errors/db-errors'
+import { normalizeString } from '@utils/string/normalize-string-util'
+import type { MusicDB, MusicListFilters } from '@domains/music/types'
+import { and, count, eq, sql, type SQL } from 'drizzle-orm'
+
+/**
+ * Filter fields used to build SQL `WHERE` clauses (excludes pagination).
+ */
+type MusicListFilterParams = Omit<MusicListFilters, 'page' | 'limit'>
+
+/**
+ * Builds SQL filter clauses for music list queries.
+ *
+ * @param filterParams - Normalized filter values excluding `page` / `limit`
+ * @returns Array of Drizzle `SQL` fragments combined with `AND`
+ *
+ * @remarks
+ * | Filter | Column | Behavior |
+ * |--------|--------|----------|
+ * | `type` | `music.type` | equality (`OP`, `ED`, `UNK`) |
+ * | `query` | `music.title` | normalized `LIKE` (spaces stripped, lowercased) |
+ *
+ * @see {@link mapMusicListFilters}
+ * @see {@link musicListRepository.getMusicList}
+ */
+export const buildMusicListFilters = ({
+  type,
+  query,
+}: MusicListFilterParams): SQL[] => {
+  const filters: SQL[] = []
+
+  if (type) {
+    filters.push(eq(music.type, type))
+  }
+
+  if (query?.trim()) {
+    const normalizedQuery = normalizeString({
+      string: query,
+      removeSpaces: true,
+      separator: '',
+      toLowerCase: true,
+    })
+
+    const queryPattern = `%${normalizedQuery}%`
+    const normalizedTitle = sql`REPLACE(LOWER(COALESCE(${music.title}, '')), ' ', '')`
+
+    filters.push(sql`${normalizedTitle} LIKE ${queryPattern}`)
+  }
+
+  return filters
+}
+
+/**
+ * Repository for querying filtered and paginated music lists.
+ *
+ * @remarks
+ * **Table:** `music`
+ *
+ * **SQL:** `SELECT *` with `LIMIT` / `OFFSET`; count uses `count()`.
+ *
+ * @see {@link musicListService}
+ * @see {@link mapMusicListToCards}
+ */
+export const musicListRepository = {
+  /**
+   * Loads a paginated music list matching the provided filters.
+   *
+   * @param filters - {@link MusicListFilters} including `page`, `limit`, and facets
+   * @returns {@link MusicDB} rows for the current page
+   *
+   * @throws {DbError} On database failure
+   *
+   * @example
+   * ```typescript
+   * const rows = await musicListRepository.getMusicList({
+   *   page: 1, limit: 20, type: 'OP',
+   * })
+   * ```
+   */
+  async getMusicList({
+    page,
+    limit,
+    ...filterParams
+  }: MusicListFilters): Promise<MusicDB[]> {
+    try {
+      const whereConditions = buildMusicListFilters(filterParams)
+
+      return await db
+        .select()
+        .from(music)
+        .where(
+          whereConditions.length > 0 ? and(...whereConditions) : undefined
+        )
+        .limit(limit)
+        .offset((page - 1) * limit)
+    } catch (error) {
+      throw dbError('getMusicList', { page, limit, ...filterParams }, error)
+    }
+  },
+
+  /**
+   * Counts music rows matching the provided filters.
+   *
+   * @param filterParams - Filters without pagination
+   * @returns Total matching count (`0` when none)
+   *
+   * @throws {DbError} On database failure
+   */
+  async getMusicListCount(
+    filterParams: MusicListFilterParams
+  ): Promise<number> {
+    try {
+      const whereConditions = buildMusicListFilters(filterParams)
+
+      const [result] = await db
+        .select({ count: count() })
+        .from(music)
+        .where(
+          whereConditions.length > 0 ? and(...whereConditions) : undefined
+        )
+
+      return result?.count ?? 0
+    } catch (error) {
+      throw dbError('getMusicListCount', filterParams, error)
+    }
+  },
+}

--- a/src/domains/music/repositories/music-relation-repository.ts
+++ b/src/domains/music/repositories/music-relation-repository.ts
@@ -5,7 +5,7 @@
 import { db } from '@db/client'
 import { musicArtist } from '@db/schemas/music-relations'
 import { artist } from '@db/schemas/artist'
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import type { MusicArtistDB } from '@domains/music/types/music-db.d-types'
 
 /**
@@ -43,6 +43,37 @@ export const musicRelationRepository = {
       .from(musicArtist)
       .innerJoin(artist, eq(musicArtist.artistId, artist.id))
       .where(eq(musicArtist.musicId, musicId))
+
+    return rows
+  },
+
+  /**
+   * Loads artists linked to multiple music records in one query.
+   *
+   * @param musicIds - Internal music identifiers
+   * @returns {@link MusicArtistDB} rows with `musicId` for grouping in list mappers
+   * @remarks Short-circuits to an empty array when `musicIds` is empty.
+   * @see {@link musicListService.getMusicList} for batch usage
+   * @example
+   * ```typescript
+   * const artists = await musicRelationRepository.findArtistsByMusicIds([1, 2, 3])
+   * ```
+   */
+  async findArtistsByMusicIds(
+    musicIds: number[]
+  ): Promise<Array<MusicArtistDB & { musicId: number }>> {
+    if (musicIds.length === 0) return []
+
+    const rows = await db
+      .select({
+        id: musicArtist.artistId,
+        name: artist.name,
+        malId: artist.malId,
+        musicId: musicArtist.musicId,
+      })
+      .from(musicArtist)
+      .innerJoin(artist, eq(musicArtist.artistId, artist.id))
+      .where(inArray(musicArtist.musicId, musicIds))
 
     return rows
   },

--- a/src/domains/music/schemas/index.ts
+++ b/src/domains/music/schemas/index.ts
@@ -9,4 +9,6 @@
  * ```
  */
 export * from './api-schema'
+export * from './music-card-schema'
 export * from './music-details-schema'
+export * from './music-list-schema'

--- a/src/domains/music/schemas/music-card-schema.ts
+++ b/src/domains/music/schemas/music-card-schema.ts
@@ -1,0 +1,44 @@
+/**
+ * Zod schemas for music card API payloads.
+ *
+ * @module domains/music/schemas/music-card-schema
+ * @remarks
+ * **Response schema** — validates mapped list/card DTOs from {@link mapMusicCard}.
+ */
+import { z } from 'zod'
+
+/**
+ * Validates an artist entry on a music card payload.
+ *
+ * @remarks
+ * | Field | Rule |
+ * |-------|------|
+ * | `name` | `z.string()` |
+ * | `malId` | `z.number()` |
+ */
+export const musicCardArtistSchema = z.object({
+  name: z.string(),
+  malId: z.number(),
+})
+
+/**
+ * Validates a compact music card shown in list views.
+ *
+ * @remarks
+ * | Field | Rule |
+ * |-------|------|
+ * | `id` | `z.number()` — internal music ID |
+ * | `title` | `z.string()` |
+ * | `type` | `'opening' \| 'ending' \| 'unknown'` |
+ * | `typeCode` | `'OP' \| 'ED' \| 'UNK'` |
+ * | `artists` | array of {@link musicCardArtistSchema} |
+ *
+ * @see {@link mapMusicCard}
+ */
+export const musicCardSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  type: z.enum(['opening', 'ending', 'unknown']),
+  typeCode: z.enum(['OP', 'ED', 'UNK']),
+  artists: z.array(musicCardArtistSchema),
+})

--- a/src/domains/music/schemas/music-list-schema.ts
+++ b/src/domains/music/schemas/music-list-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Zod schemas for music list and filter API payloads.
+ *
+ * @module domains/music/schemas/music-list-schema
+ */
+import { createApiResponseSchema } from '@shared/schemas/api-schema'
+import { musicCardSchema } from '@domains/music/schemas/music-card-schema'
+import { z } from 'zod'
+
+/**
+ * **Request query schema** — raw query parameters for music list requests.
+ *
+ * @remarks
+ * | Field | Validation |
+ * |-------|------------|
+ * | `page` | `z.coerce.number().int().min(1).default(1)` |
+ * | `limit` | `z.coerce.number().int().min(1).max(100).default(10)` |
+ * | `type` | optional string — `OP`, `ED`, `UNK`, or labels `opening` / `ending` (normalized in mapper) |
+ * | `query` | optional search string (title substring) |
+ */
+export const musicListFiltersParamsSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+  type: z.string().optional(),
+  query: z.string().optional(),
+})
+
+/**
+ * **Normalized filters** — after {@link mapMusicListFilters}; used by repos and cache keys.
+ */
+export const musicListFiltersSchema = musicListFiltersParamsSchema.extend({
+  type: z.enum(['OP', 'ED', 'UNK']).optional(),
+})
+
+/**
+ * **Full request schema** for `GET /api/music` (list).
+ */
+export const musicListRequestSchema = z.object({
+  params: z.object({}).optional().default({}),
+  query: musicListFiltersParamsSchema,
+  body: z.unknown().optional(),
+})
+
+/**
+ * **Response schema** — paginated cards (total count returned separately by route).
+ */
+export const musicListResponseSchema = createApiResponseSchema(
+  z.array(musicCardSchema)
+)

--- a/src/domains/music/services/index.ts
+++ b/src/domains/music/services/index.ts
@@ -3,9 +3,11 @@
  * @remarks Barrel exports for music application services that orchestrate repositories,
  * mappers, and cache layers.
  * @see {@link ./music-service} for music detail reads
+ * @see {@link ./music-list-service} for paginated list reads
  * @example
  * ```typescript
- * import { musicService } from '@domains/music/services'
+ * import { musicService, musicListService } from '@domains/music/services'
  * ```
  */
+export * from './music-list-service'
 export * from './music-service'

--- a/src/domains/music/services/music-list-service.ts
+++ b/src/domains/music/services/music-list-service.ts
@@ -1,0 +1,96 @@
+/**
+ * Application service for paginated music list data.
+ *
+ * @module domains/music/services/music-list-service
+ */
+import { withCache } from '@lib/cache'
+import { musicListCache } from '@domains/music/cache/music-list-cache'
+import { mapMusicListToCards } from '@domains/music/mappers/music-card-mapper'
+import { mapMusicListFilters } from '@domains/music/mappers/music-filters-mapper'
+import { musicListRepository } from '@domains/music/repositories/music-list-repository'
+import { musicRelationRepository } from '@domains/music/repositories/music-relation-repository'
+import type {
+  MusicArtistDB,
+  MusicCard,
+  MusicListFilters,
+  MusicListFiltersParams,
+} from '@domains/music/types'
+
+/**
+ * Groups artist rows by parent music ID for card mapping.
+ *
+ * @internal
+ */
+const groupArtistsByMusicId = (
+  artists: Array<MusicArtistDB & { musicId: number }>
+): Record<number, MusicArtistDB[]> => {
+  return artists.reduce<Record<number, MusicArtistDB[]>>((acc, row) => {
+    const { musicId, ...artist } = row
+    if (!acc[musicId]) {
+      acc[musicId] = []
+    }
+    acc[musicId].push(artist)
+    return acc
+  }, {})
+}
+
+/**
+ * Coordinates repository access, mapping, and caching for music list pages.
+ *
+ * @remarks
+ * **Pipeline:** `mapMusicListFilters(params)` → `music:list:{JSON}` → list + count
+ * repos → batch artists → `mapMusicListToCards` → `{ list, total }`
+ *
+ * **Cache TTL:** {@link CacheTtl.Medium} (3600 s)
+ *
+ * @see {@link musicListCache}
+ */
+export const musicListService = {
+  /**
+   * Loads a filtered, paginated music list with total count.
+   *
+   * @param filtersParams - Raw query parameters (coerced by Zod at the route)
+   * @returns `{ list: MusicCard[], total: number }` for the current filter page
+   *
+   * @throws {InfraError} On repository or cache failures
+   *
+   * @example
+   * ```typescript
+   * const { list, total } = await musicListService.getMusicList({
+   *   page: 1, limit: 10, type: 'OP',
+   * })
+   * ```
+   */
+  async getMusicList(
+    filtersParams: MusicListFiltersParams
+  ): Promise<{ list: MusicCard[]; total: number }> {
+    const filters: MusicListFilters = mapMusicListFilters(filtersParams)
+
+    return withCache({
+      key: musicListCache.key(filters),
+      getCache: () => musicListCache.get(filters),
+      setCache: (_, value) => musicListCache.set(filters, value),
+      compute: async () => {
+        const [musicList, total] = await Promise.all([
+          musicListRepository.getMusicList(filters),
+          musicListRepository.getMusicListCount(filters),
+        ])
+
+        if (musicList.length === 0) {
+          return { list: [], total }
+        }
+
+        const musicIds = musicList.map((m) => m.id)
+        const artists =
+          await musicRelationRepository.findArtistsByMusicIds(musicIds)
+
+        const list = mapMusicListToCards({
+          musicList,
+          artistsByMusicId: groupArtistsByMusicId(artists),
+        })
+
+        return { list, total }
+      },
+    })
+  },
+}

--- a/src/domains/music/types/index.ts
+++ b/src/domains/music/types/index.ts
@@ -11,3 +11,5 @@
  */
 export * from './music-db.d-types'
 export * from './music-details.d-types'
+export * from './music-card.d-types'
+export * from './music-list.d-types'

--- a/src/domains/music/types/music-card.d-types.ts
+++ b/src/domains/music/types/music-card.d-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Domain types for music card payloads.
+ *
+ * @module domains/music/types/music-card
+ */
+import { z } from 'zod'
+import { musicCardSchema } from '@domains/music/schemas/music-card-schema'
+
+/**
+ * Compact music summary used in list views.
+ *
+ * @remarks
+ * Inferred from {@link musicCardSchema}. Produced by {@link mapMusicCard}.
+ *
+ * @see {@link MusicListResponse}
+ */
+export type MusicCard = z.infer<typeof musicCardSchema>

--- a/src/domains/music/types/music-list.d-types.ts
+++ b/src/domains/music/types/music-list.d-types.ts
@@ -1,0 +1,36 @@
+/**
+ * Domain types for music list and filter payloads.
+ *
+ * @module domains/music/types/music-list
+ */
+import {
+  musicListFiltersParamsSchema,
+  musicListFiltersSchema,
+  musicListResponseSchema,
+} from '@domains/music/schemas/music-list-schema'
+import { z } from 'zod'
+
+/**
+ * Normalized list filters used by repositories and cache keys.
+ *
+ * @remarks
+ * `type` is normalized to DB codes (`OP`, `ED`, `UNK`) via {@link mapMusicListFilters}.
+ *
+ * @see {@link musicListRepository}
+ * @see {@link musicListCache}
+ */
+export type MusicListFilters = z.infer<typeof musicListFiltersSchema>
+
+/**
+ * Raw query parameters for music list requests (pre-mapper).
+ *
+ * @see {@link musicListFiltersParamsSchema}
+ */
+export type MusicListFiltersParams = z.infer<
+  typeof musicListFiltersParamsSchema
+>
+
+/**
+ * API response wrapping a paginated music card array.
+ */
+export type MusicListResponse = z.infer<typeof musicListResponseSchema>

--- a/src/lib/cache/cache-primitives.ts
+++ b/src/lib/cache/cache-primitives.ts
@@ -1,0 +1,108 @@
+/**
+ * @module lib/cache/cache-primitives
+ *
+ * Generic Redis-backed primitives: get, set, and delete. Serializes values as JSON strings and
+ * delegates transport to the shared Upstash client. The read-through `withCache` wrapper lives in
+ * {@link module:lib/cache/cache-store}.
+ *
+ * @remarks
+ * `cacheGet` returns `null` for missing keys and for falsy Redis responses (empty string, etc.).
+ * Upstash/network errors propagate as rejected promises without translation.
+ *
+ * @see {@link module:lib/cache/client} for the underlying Redis instance
+ * @see {@link module:lib/cache/config} for key prefixes and TTL presets
+ */
+import { redis } from '@lib/cache/client'
+
+/**
+ * Options for {@link cacheSet} controlling key expiry.
+ *
+ * @property ttlSeconds - Optional expiry in seconds. When omitted or `<= 0`,
+ * the key persists until explicit {@link cacheDel} or Redis eviction policy.
+ */
+export type CacheGetSetOptions = {
+  ttlSeconds?: number
+}
+
+/**
+ * Reads a JSON-deserialized cached value by key.
+ *
+ * @typeParam T - Expected cached value type; caller responsible for shape correctness.
+ * @param key - Non-empty Redis cache key. Invalid keys behave per Upstash rules.
+ * @returns The cached value when present and truthy after Redis `GET`; `null`
+ * when the key is missing or Redis returns a falsy payload. Does not distinguish
+ * "cached null" from miss unless callers encode sentinels in `T`.
+ *
+ * @throws Rejects when Upstash REST request fails (network, auth, rate limit).
+ *
+ * @example
+ * ```typescript
+ * type AnimeDetail = { malId: number; title: string }
+ * const detail = await cacheGet<AnimeDetail>('anime:details:5114')
+ * if (detail === null) {
+ *   // cache miss — fetch from database
+ * }
+ * ```
+ *
+ * @see {@link cacheSet} for writing values
+ * @see {@link withCache} for read-through pattern
+ */
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  const raw = await redis.get<T>(key)
+  if (!raw) return null
+
+  return raw
+}
+
+/**
+ * Stores a value in Redis as a JSON string, optionally with TTL expiry.
+ *
+ * @typeParam T - Value type to serialize via `JSON.stringify`.
+ * @param key - Redis cache key. Overwrites existing value atomically.
+ * @param value - Serializable value; `undefined` becomes omitted in JSON.
+ * Functions, `BigInt`, and circular structures will cause `JSON.stringify` to throw.
+ * @param options - Optional TTL configuration via {@link CacheGetSetOptions}.
+ * @returns `Promise<void>` resolving when Upstash acknowledges the write.
+ *
+ * @throws Rejects on non-serializable `value`, Upstash errors, or invalid credentials.
+ * @throws {TypeError} When `JSON.stringify` fails for exotic values.
+ *
+ * @example
+ * ```typescript
+ * await cacheSet('anime:list:page:1', { items: [], total: 0 }, { ttlSeconds: 3600 })
+ * ```
+ *
+ * @see {@link CacheTtl} for standard expiry durations
+ */
+export async function cacheSet<T>(
+  key: string,
+  value: T,
+  { ttlSeconds }: CacheGetSetOptions = {}
+): Promise<void> {
+  const payload = JSON.stringify(value)
+
+  if (ttlSeconds && ttlSeconds > 0) {
+    await redis.set(key, payload, { ex: ttlSeconds })
+  } else {
+    await redis.set(key, payload)
+  }
+}
+
+/**
+ * Removes a cached entry by key.
+ *
+ * @param key - Redis cache key to delete. No-op when key does not exist.
+ * @returns `Promise<void>` resolving after Upstash `DEL` completes.
+ *
+ * @throws Rejects on Upstash transport or authentication failures.
+ *
+ * @example
+ * ```typescript
+ * await cacheDel('anime:full:5114') // invalidate after admin update
+ * ```
+ *
+ * @see {@link cacheSet} for writing entries
+ */
+export async function cacheDel(key: string): Promise<void> {
+  await redis.del(key)
+}

--- a/src/lib/cache/cache-store.ts
+++ b/src/lib/cache/cache-store.ts
@@ -1,30 +1,18 @@
 /**
  * @module lib/cache/cache-store
  *
- * Generic Redis-backed cache helpers implementing get, set, delete, and a
- * read-through `withCache` wrapper. Serializes values as JSON strings and
- * delegates transport to the shared Upstash client.
+ * Read-through `withCache` wrapper built on the cache primitives. Re-exports
+ * {@link cacheGet}, {@link cacheSet}, and {@link cacheDel} from
+ * {@link module:lib/cache/cache-primitives} so `@lib/cache/cache-store` remains the single entry
+ * point for the cache helpers.
  *
  * @remarks
- * `cacheGet` returns `null` for missing keys and for falsy Redis responses
- * (empty string, etc.). Callers distinguish cache miss from legitimately
- * cached empty results via `shouldCache` in {@link withCache}. Upstash/network
- * errors propagate as rejected promises without translation.
+ * Callers distinguish cache miss from legitimately cached empty results via `shouldCache`.
  *
- * @see {@link module:lib/cache/client} for the underlying Redis instance
+ * @see {@link module:lib/cache/cache-primitives} for get/set/del
  * @see {@link module:lib/cache/config} for key prefixes and TTL presets
  */
-import { redis } from '@lib/cache/client'
-
-/**
- * Options for {@link cacheSet} controlling key expiry.
- *
- * @property ttlSeconds - Optional expiry in seconds. When omitted or `<= 0`,
- * the key persists until explicit {@link cacheDel} or Redis eviction policy.
- */
-type CacheGetSetOptions = {
-  ttlSeconds?: number
-}
+export * from '@lib/cache/cache-primitives'
 
 /**
  * Options for {@link withCache} read-through orchestration.
@@ -43,89 +31,6 @@ type WithCacheOptions<T> = {
   setCache: (key: string, value: T) => Promise<void>
   compute: () => Promise<T>
   shouldCache?: (result: T) => boolean
-}
-
-/**
- * Reads a JSON-deserialized cached value by key.
- *
- * @typeParam T - Expected cached value type; caller responsible for shape correctness.
- * @param key - Non-empty Redis cache key. Invalid keys behave per Upstash rules.
- * @returns The cached value when present and truthy after Redis `GET`; `null`
- * when the key is missing or Redis returns a falsy payload. Does not distinguish
- * "cached null" from miss unless callers encode sentinels in `T`.
- *
- * @throws Rejects when Upstash REST request fails (network, auth, rate limit).
- *
- * @example
- * ```typescript
- * type AnimeDetail = { malId: number; title: string }
- * const detail = await cacheGet<AnimeDetail>('anime:details:5114')
- * if (detail === null) {
- *   // cache miss — fetch from database
- * }
- * ```
- *
- * @see {@link cacheSet} for writing values
- * @see {@link withCache} for read-through pattern
- */
-export async function cacheGet<T>(key: string): Promise<T | null> {
-  const raw = await redis.get<T>(key)
-  if (!raw) return null
-
-  return raw
-}
-
-/**
- * Stores a value in Redis as a JSON string, optionally with TTL expiry.
- *
- * @typeParam T - Value type to serialize via `JSON.stringify`.
- * @param key - Redis cache key. Overwrites existing value atomically.
- * @param value - Serializable value; `undefined` becomes omitted in JSON.
- * Functions, `BigInt`, and circular structures will cause `JSON.stringify` to throw.
- * @param options - Optional TTL configuration via {@link CacheGetSetOptions}.
- * @returns `Promise<void>` resolving when Upstash acknowledges the write.
- *
- * @throws Rejects on non-serializable `value`, Upstash errors, or invalid credentials.
- * @throws {TypeError} When `JSON.stringify` fails for exotic values.
- *
- * @example
- * ```typescript
- * await cacheSet('anime:list:page:1', { items: [], total: 0 }, { ttlSeconds: 3600 })
- * ```
- *
- * @see {@link CacheTtl} for standard expiry durations
- */
-export async function cacheSet<T>(
-  key: string,
-  value: T,
-  { ttlSeconds }: CacheGetSetOptions = {}
-): Promise<void> {
-  const payload = JSON.stringify(value)
-
-  if (ttlSeconds && ttlSeconds > 0) {
-    await redis.set(key, payload, { ex: ttlSeconds })
-  } else {
-    await redis.set(key, payload)
-  }
-}
-
-/**
- * Removes a cached entry by key.
- *
- * @param key - Redis cache key to delete. No-op when key does not exist.
- * @returns `Promise<void>` resolving after Upstash `DEL` completes.
- *
- * @throws Rejects on Upstash transport or authentication failures.
- *
- * @example
- * ```typescript
- * await cacheDel('anime:full:5114') // invalidate after admin update
- * ```
- *
- * @see {@link cacheSet} for writing entries
- */
-export async function cacheDel(key: string): Promise<void> {
-  await redis.del(key)
 }
 
 /**

--- a/src/lib/cache/config.ts
+++ b/src/lib/cache/config.ts
@@ -42,6 +42,9 @@ export enum CacheKeyPrefix {
   /** Music track detail payloads. Value: `'music:details'`. */
   MusicDetails = 'music:details',
 
+  /** Paginated or filtered music list responses. Value: `'music:list'`. */
+  MusicList = 'music:list',
+
   /** Extended user profile preferences and display fields. Value: `'user:profile'`. */
   UserProfile = 'user:profile',
 }

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -18,6 +18,7 @@
  * @see {@link module:config/env} for Upstash credentials
  * @see {@link module:lib/cache/cache-store} for read-through pattern
  */
+export * from './cache-primitives'
 export * from './cache-store'
 export * from './client'
 export * from './config'

--- a/src/pages/api/music/index.ts
+++ b/src/pages/api/music/index.ts
@@ -1,0 +1,116 @@
+/**
+ * Paginated music list API endpoint.
+ *
+ * @module pages/api/music/index
+ *
+ * **Route:** `GET /api/music`
+ *
+ * **Authentication:** Public — no session required ({@link isPublicRoute} allowlists `/api/music`).
+ *
+ * Returns a filtered, paginated list of music cards for browse and search flows.
+ *
+ * @see {@link musicListRequestSchema} — request validation schema
+ * @see {@link musicListResponseSchema} — response validation schema
+ * @see {@link musicListService.getMusicList} — list query service
+ * @see {@link mapErrorToHttp} — error-to-HTTP mapping
+ */
+
+import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
+import { withZodValidation } from '@http/with-validation'
+import {
+  musicListRequestSchema,
+  musicListResponseSchema,
+} from '@domains/music/schemas/music-list-schema'
+import { musicListService } from '@domains/music/services/music-list-service'
+import type { APIRoute } from 'astro'
+
+/**
+ * Returns a paginated, filterable music card list.
+ *
+ * @remarks
+ * **Request**
+ *
+ * | Source | Field | Type | Required | Default | Description |
+ * |--------|-------|------|----------|---------|-------------|
+ * | Query | `page` | `number` | No | `1` | Page number (integer ≥ 1) |
+ * | Query | `limit` | `number` | No | `10` | Page size (integer 1–100) |
+ * | Query | `type` | `string` | No | — | Music type: `OP`, `ED`, `UNK`, or labels `opening` / `ending` |
+ * | Query | `query` | `string` | No | — | Free-text search on title |
+ *
+ * **Success response — `200 OK`**
+ *
+ * ```typescript
+ * {
+ *   data: Array<{
+ *     id: number
+ *     title: string
+ *     type: 'opening' | 'ending' | 'unknown'
+ *     typeCode: 'OP' | 'ED' | 'UNK'
+ *     artists: Array<{ name: string; malId: number }>
+ *   }>
+ *   status: 200
+ *   meta: {
+ *     page: number
+ *     total: number
+ *     hasNext: boolean
+ *   }
+ * }
+ * ```
+ *
+ * **Error responses** (JSON envelope: `{ data: null, status, error, meta }`)
+ *
+ * | Status | Code | When |
+ * |--------|------|------|
+ * | 400 | `VALIDATION_ERROR` | Query params fail {@link musicListRequestSchema} validation |
+ * | 500 | `DB_ERROR` | Database query failed |
+ * | 500 | `CACHE_ERROR` | Cache read/write failure |
+ * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ *
+ * @example
+ * ```bash
+ * curl "http://localhost:4321/api/music?page=1&limit=20&type=OP&query=unravel"
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const res = await fetch('/api/music?page=1&limit=10&type=opening')
+ * const { data, meta } = await res.json()
+ * // data: MusicCard[], meta: { page, total, hasNext }
+ * ```
+ */
+export const GET: APIRoute = withZodValidation(musicListRequestSchema)(async ({
+  validated,
+}) => {
+  try {
+    const { list: musicCards, total } = await musicListService.getMusicList(
+      validated.query
+    )
+    const payload = {
+      data: musicCards,
+      status: 200,
+      meta: {
+        page: validated.query.page,
+        total,
+        hasNext: validated.query.page * validated.query.limit < total,
+      },
+    }
+    const responseBody = musicListResponseSchema.parse(payload)
+
+    return new Response(JSON.stringify(responseBody), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    const { status, body } = mapErrorToHttp(error)
+    const payload = {
+      data: null,
+      status,
+      error: body.message ?? 'Unexpected error',
+      meta: body.meta ?? {},
+    }
+
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+})

--- a/src/shared/errors/app-error.ts
+++ b/src/shared/errors/app-error.ts
@@ -21,61 +21,11 @@
  */
 
 import type { ErrorCode } from '@shared/errors/codes'
+import { BaseError } from '@shared/errors/base-error'
 
-/**
- * Severity level used for logging and monitoring classification.
- *
- * @remarks
- * Assigned per error subclass: `warn` for validation/auth, `error` for domain, `critical` for infra.
- */
-export type ErrorSeverity = 'info' | 'warn' | 'error' | 'critical'
-
-/**
- * Abstract base for all first-class application errors.
- *
- * @remarks
- * Preserves prototype chain for `instanceof` checks after extension. Subclasses set `name` to their
- * class name for clearer stack traces and serialization.
- */
-export abstract class BaseError extends Error {
-  /** Stable application error code from {@link ErrorCodes}. */
-  readonly code: ErrorCode
-  /** Logging/monitoring severity for this failure. */
-  readonly severity: ErrorSeverity
-  /**
-   * Optional structured context attached at throw time.
-   * @remarks Exposed to clients as `meta.details` when mapped by {@link mapErrorToHttp}.
-   */
-  readonly details?: unknown
-  /** Optional underlying error that triggered this failure (DB driver, fetch, etc.). */
-  readonly cause?: unknown
-
-  /**
-   * @param name - Error class name exposed on {@link Error.name}
-   * @param code - Stable application error code
-   * @param message - Human-readable error message
-   * @param severity - Logging severity; defaults to `error`
-   * @param details - Optional structured context for clients or logs
-   * @param cause - Optional underlying error that triggered this failure
-   */
-  protected constructor(
-    name: string,
-    code: ErrorCode,
-    message: string,
-    severity: ErrorSeverity = 'error',
-    details?: unknown,
-    cause?: unknown
-  ) {
-    super(message)
-    this.name = name
-    this.code = code
-    this.severity = severity
-    this.details = details
-    this.cause = cause
-
-    Object.setPrototypeOf(this, new.target.prototype)
-  }
-}
+// Re-exported so consumers importing from `@shared/errors/app-error` keep access to the base
+// class and severity type.
+export * from '@shared/errors/base-error'
 
 /**
  * Business-rule violation raised by domain logic (not found, invalid id, unsupported path, etc.).

--- a/src/shared/errors/base-error.ts
+++ b/src/shared/errors/base-error.ts
@@ -1,0 +1,69 @@
+/**
+ * Abstract base class and severity type for the application error hierarchy.
+ *
+ * @module shared/errors/base-error
+ * @remarks
+ * All first-class application errors extend {@link BaseError}. Concrete subclasses
+ * ({@link DomainError}, {@link InfraError}, {@link ValidationError}, {@link AuthError}) live in
+ * {@link module:shared/errors/app-error}.
+ *
+ * @see {@link ErrorCodes} — stable string codes carried on every error
+ * @see {@link mapErrorToHttp} — HTTP status and body mapping
+ */
+
+import type { ErrorCode } from '@shared/errors/codes'
+
+/**
+ * Severity level used for logging and monitoring classification.
+ *
+ * @remarks
+ * Assigned per error subclass: `warn` for validation/auth, `error` for domain, `critical` for infra.
+ */
+export type ErrorSeverity = 'info' | 'warn' | 'error' | 'critical'
+
+/**
+ * Abstract base for all first-class application errors.
+ *
+ * @remarks
+ * Preserves prototype chain for `instanceof` checks after extension. Subclasses set `name` to their
+ * class name for clearer stack traces and serialization.
+ */
+export abstract class BaseError extends Error {
+  /** Stable application error code from {@link ErrorCodes}. */
+  readonly code: ErrorCode
+  /** Logging/monitoring severity for this failure. */
+  readonly severity: ErrorSeverity
+  /**
+   * Optional structured context attached at throw time.
+   * @remarks Exposed to clients as `meta.details` when mapped by {@link mapErrorToHttp}.
+   */
+  readonly details?: unknown
+  /** Optional underlying error that triggered this failure (DB driver, fetch, etc.). */
+  readonly cause?: unknown
+
+  /**
+   * @param name - Error class name exposed on {@link Error.name}
+   * @param code - Stable application error code
+   * @param message - Human-readable error message
+   * @param severity - Logging severity; defaults to `error`
+   * @param details - Optional structured context for clients or logs
+   * @param cause - Optional underlying error that triggered this failure
+   */
+  protected constructor(
+    name: string,
+    code: ErrorCode,
+    message: string,
+    severity: ErrorSeverity = 'error',
+    details?: unknown,
+    cause?: unknown
+  ) {
+    super(message)
+    this.name = name
+    this.code = code
+    this.severity = severity
+    this.details = details
+    this.cause = cause
+
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}

--- a/src/shared/errors/error-http-maps.ts
+++ b/src/shared/errors/error-http-maps.ts
@@ -1,0 +1,127 @@
+/**
+ * Per-class HTTP mapping helpers for the application error hierarchy.
+ *
+ * @module shared/errors/error-http-maps
+ * @remarks Consumed by {@link mapErrorToHttp}. Each helper maps a specific {@link BaseError}
+ * subclass to a status/body pair and performs the appropriate logging (no Sentry here; Sentry
+ * capture for 500s happens in the top-level mapper).
+ */
+
+import { AuthError, BaseError, DomainError } from '@shared/errors/app-error'
+import { ErrorCodes, type ErrorCode } from '@shared/errors/codes'
+import type {
+  HttpErrorBody,
+  HttpErrorResponse,
+} from '@shared/errors/http-error-types'
+import { logger } from '@utils/logger-util'
+
+/**
+ * Auth error codes that map to **401 Unauthorized**.
+ *
+ * @remarks
+ * Used by {@link mapAuthErrorToHttp}. All other recognized {@link AuthError} codes fall through
+ * to {@link ErrorCodes.AUTH_FORBIDDEN} (403) when explicitly matched.
+ *
+ * @internal
+ */
+const UNAUTHORIZED_AUTH_CODES = new Set<ErrorCode>([
+  ErrorCodes.AUTH_REQUIRED,
+  ErrorCodes.AUTH_INVALID_TOKEN,
+  ErrorCodes.AUTH_SESSION_EXPIRED,
+])
+
+/**
+ * Domain error codes that map to **404 Not Found**.
+ *
+ * @remarks
+ * Any other {@link DomainError} code maps to **400 Bad Request** and is logged at `error` severity.
+ *
+ * @internal
+ */
+const NOT_FOUND_DOMAIN_CODES = new Set<ErrorCode>([
+  ErrorCodes.ANIME_NOT_FOUND,
+  ErrorCodes.MUSIC_NOT_FOUND,
+  ErrorCodes.WATCH_STATE_NOT_FOUND,
+  ErrorCodes.COLLECTION_NOT_FOUND,
+  ErrorCodes.USER_NOT_FOUND,
+  ErrorCodes.MEDIA_NOT_FOUND,
+])
+
+/**
+ * Builds the standard HTTP error body from a {@link BaseError} instance.
+ *
+ * @param error - Application error with `code`, `message`, and optional `details`
+ * @returns Body where `meta.details` echoes `error.details` when defined
+ *
+ * @internal
+ */
+export function buildAppErrorBody(error: BaseError): HttpErrorBody {
+  return {
+    code: error.code,
+    message: error.message,
+    meta: { details: error.details },
+  }
+}
+
+/**
+ * Maps {@link AuthError} instances to 401 or 403 responses.
+ *
+ * @param error - Authentication or authorization failure
+ * @returns HTTP response for recognized auth codes, or `undefined` if the code is not handled here
+ *
+ * @remarks
+ * - **401**: `AUTH_REQUIRED`, `AUTH_INVALID_TOKEN`, `AUTH_SESSION_EXPIRED` — logged at `warn`.
+ * - **403**: `AUTH_FORBIDDEN` — logged at `warn`.
+ * - Unrecognized {@link AuthError} codes return `undefined` so {@link mapErrorToHttp} can fall through
+ *   to generic unknown-error handling.
+ *
+ * @internal
+ */
+export function mapAuthErrorToHttp(
+  error: AuthError
+): HttpErrorResponse | undefined {
+  if (UNAUTHORIZED_AUTH_CODES.has(error.code)) {
+    logger.warn({ err: error }, 'Auth error - unauthorized')
+    return {
+      status: 401,
+      body: buildAppErrorBody(error),
+    }
+  }
+
+  if (error.code === ErrorCodes.AUTH_FORBIDDEN) {
+    logger.warn({ err: error }, 'Auth error - forbidden')
+    return {
+      status: 403,
+      body: buildAppErrorBody(error),
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Maps {@link DomainError} instances to 404 or 400 responses.
+ *
+ * @param error - Business-rule violation from domain logic
+ * @returns **404** when `error.code` is in {@link NOT_FOUND_DOMAIN_CODES}; otherwise **400**
+ *
+ * @remarks
+ * Not-found codes are logged at `warn`; other domain errors at `error`. Neither path reports to Sentry.
+ *
+ * @internal
+ */
+export function mapDomainErrorToHttp(error: DomainError): HttpErrorResponse {
+  if (NOT_FOUND_DOMAIN_CODES.has(error.code)) {
+    logger.warn({ err: error }, 'Domain error - not found')
+    return {
+      status: 404,
+      body: buildAppErrorBody(error),
+    }
+  }
+
+  logger.error({ err: error }, 'Domain error')
+  return {
+    status: 400,
+    body: buildAppErrorBody(error),
+  }
+}

--- a/src/shared/errors/http-error-types.ts
+++ b/src/shared/errors/http-error-types.ts
@@ -1,0 +1,34 @@
+/**
+ * HTTP error payload types shared by the error-to-HTTP mapper.
+ *
+ * @module shared/errors/http-error-types
+ * @remarks Defines the serialized `{ code, message, meta }` body and the `{ status, body }`
+ * envelope produced by {@link mapErrorToHttp}.
+ */
+
+/**
+ * JSON-serializable error payload returned in HTTP responses.
+ *
+ * @remarks
+ * Serialized as the `body` half of {@link HttpErrorResponse}. The `meta.details` field mirrors
+ * `BaseError.details` when present; it may contain Zod issue arrays, entity identifiers, or
+ * operation names depending on which factory or class created the error.
+ */
+export type HttpErrorBody = {
+  /** Stable application error code (e.g. `ANIME_NOT_FOUND`). */
+  code: string
+  /** Human-readable message safe to expose to API clients (may be generic for 500 responses). */
+  message: string
+  /** Optional wrapper; `details` holds structured context from the originating error. */
+  meta?: Record<string, unknown>
+}
+
+/**
+ * HTTP status plus structured error body produced by the mapper.
+ */
+export type HttpErrorResponse = {
+  /** HTTP status code (400, 401, 403, 404, or 500). */
+  status: number
+  /** JSON error body with `code`, `message`, and optional `meta`. */
+  body: HttpErrorBody
+}

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -12,8 +12,11 @@
  * @see {@link module:shared/errors/map-error-to-http} — HTTP status mapping and Sentry rules
  */
 
+export * from './base-error'
 export * from './app-error'
 export * from './auth-errors'
 export * from './codes'
 export * from './db-errors'
+export * from './http-error-types'
+export * from './error-http-maps'
 export * from './map-error-to-http'

--- a/src/shared/errors/map-error-to-http.ts
+++ b/src/shared/errors/map-error-to-http.ts
@@ -6,7 +6,8 @@
  * This module is the single bridge between the {@link BaseError} hierarchy and HTTP API responses.
  * Route wrappers such as {@link withErrorHandling} and {@link withZodValidation} rely on
  * {@link mapErrorToHttp} (directly or via {@link createErrorResponse}) so clients always receive
- * a consistent `{ code, message, meta }` error body shape.
+ * a consistent `{ code, message, meta }` error body shape. Per-class mapping helpers live in
+ * {@link error-http-maps}; payload types in {@link http-error-types}.
  *
  * **HTTP status mapping overview**
  *
@@ -39,149 +40,19 @@
 
 import {
   AuthError,
-  BaseError,
   DomainError,
   InfraError,
   ValidationError,
 } from '@shared/errors/app-error'
-import { ErrorCodes, type ErrorCode } from '@shared/errors/codes'
+import { ErrorCodes } from '@shared/errors/codes'
+import type { HttpErrorResponse } from '@shared/errors/http-error-types'
+import {
+  buildAppErrorBody,
+  mapAuthErrorToHttp,
+  mapDomainErrorToHttp,
+} from '@shared/errors/error-http-maps'
 import { logger } from '@utils/logger-util'
 import * as SentryNode from '@sentry/node'
-
-/**
- * JSON-serializable error payload returned in HTTP responses.
- *
- * @remarks
- * Serialized as the `body` half of {@link HttpErrorResponse}. The `meta.details` field mirrors
- * `BaseError.details` when present; it may contain Zod issue arrays, entity identifiers, or
- * operation names depending on which factory or class created the error.
- */
-type HttpErrorBody = {
-  /** Stable application error code (e.g. `ANIME_NOT_FOUND`). */
-  code: string
-  /** Human-readable message safe to expose to API clients (may be generic for 500 responses). */
-  message: string
-  /** Optional wrapper; `details` holds structured context from the originating error. */
-  meta?: Record<string, unknown>
-}
-
-/**
- * HTTP status plus structured error body produced by the mapper.
- */
-type HttpErrorResponse = {
-  /** HTTP status code (400, 401, 403, 404, or 500). */
-  status: number
-  /** JSON error body with `code`, `message`, and optional `meta`. */
-  body: HttpErrorBody
-}
-
-/**
- * Auth error codes that map to **401 Unauthorized**.
- *
- * @remarks
- * Used by {@link mapAuthErrorToHttp}. All other recognized {@link AuthError} codes fall through
- * to {@link ErrorCodes.AUTH_FORBIDDEN} (403) when explicitly matched.
- *
- * @internal
- */
-const UNAUTHORIZED_AUTH_CODES = new Set<ErrorCode>([
-  ErrorCodes.AUTH_REQUIRED,
-  ErrorCodes.AUTH_INVALID_TOKEN,
-  ErrorCodes.AUTH_SESSION_EXPIRED,
-])
-
-/**
- * Domain error codes that map to **404 Not Found**.
- *
- * @remarks
- * Any other {@link DomainError} code maps to **400 Bad Request** and is logged at `error` severity.
- *
- * @internal
- */
-const NOT_FOUND_DOMAIN_CODES = new Set<ErrorCode>([
-  ErrorCodes.ANIME_NOT_FOUND,
-  ErrorCodes.MUSIC_NOT_FOUND,
-  ErrorCodes.WATCH_STATE_NOT_FOUND,
-  ErrorCodes.COLLECTION_NOT_FOUND,
-  ErrorCodes.USER_NOT_FOUND,
-])
-
-/**
- * Builds the standard HTTP error body from a {@link BaseError} instance.
- *
- * @param error - Application error with `code`, `message`, and optional `details`
- * @returns Body where `meta.details` echoes `error.details` when defined
- *
- * @internal
- */
-function buildAppErrorBody(error: BaseError): HttpErrorBody {
-  return {
-    code: error.code,
-    message: error.message,
-    meta: { details: error.details },
-  }
-}
-
-/**
- * Maps {@link AuthError} instances to 401 or 403 responses.
- *
- * @param error - Authentication or authorization failure
- * @returns HTTP response for recognized auth codes, or `undefined` if the code is not handled here
- *
- * @remarks
- * - **401**: `AUTH_REQUIRED`, `AUTH_INVALID_TOKEN`, `AUTH_SESSION_EXPIRED` — logged at `warn`.
- * - **403**: `AUTH_FORBIDDEN` — logged at `warn`.
- * - Unrecognized {@link AuthError} codes return `undefined` so {@link mapErrorToHttp} can fall through
- *   to generic unknown-error handling.
- *
- * @internal
- */
-function mapAuthErrorToHttp(error: AuthError): HttpErrorResponse | undefined {
-  if (UNAUTHORIZED_AUTH_CODES.has(error.code)) {
-    logger.warn({ err: error }, 'Auth error - unauthorized')
-    return {
-      status: 401,
-      body: buildAppErrorBody(error),
-    }
-  }
-
-  if (error.code === ErrorCodes.AUTH_FORBIDDEN) {
-    logger.warn({ err: error }, 'Auth error - forbidden')
-    return {
-      status: 403,
-      body: buildAppErrorBody(error),
-    }
-  }
-
-  return undefined
-}
-
-/**
- * Maps {@link DomainError} instances to 404 or 400 responses.
- *
- * @param error - Business-rule violation from domain logic
- * @returns **404** when `error.code` is in {@link NOT_FOUND_DOMAIN_CODES}; otherwise **400**
- *
- * @remarks
- * Not-found codes are logged at `warn`; other domain errors at `error`. Neither path reports to Sentry.
- *
- * @internal
- */
-function mapDomainErrorToHttp(error: DomainError): HttpErrorResponse {
-  if (NOT_FOUND_DOMAIN_CODES.has(error.code)) {
-    logger.warn({ err: error }, 'Domain error - not found')
-    return {
-      status: 404,
-      body: buildAppErrorBody(error),
-    }
-  }
-
-    logger.error({ err: error }, 'Domain error')
-  return {
-    status: 400,
-    body: buildAppErrorBody(error),
-  }
-}
 
 /**
  * Converts a thrown value into an HTTP status and structured JSON error body.

--- a/src/shared/http/api-response-serialize-util.ts
+++ b/src/shared/http/api-response-serialize-util.ts
@@ -1,0 +1,67 @@
+/**
+ * Serialization helpers for the standard JSON API response envelope.
+ *
+ * @module shared/http/api-response-serialize-util
+ * @remarks
+ * Turns an {@link ApiEnvelope} into an HTTP {@link Response} and merges auxiliary headers (e.g.
+ * Better Auth `Set-Cookie`). Envelope builders live in {@link create-api-response-util}.
+ */
+import type { ApiEnvelope } from '@shared/http/create-api-response-util'
+
+/**
+ * Serializes an API envelope into a JSON {@link Response}.
+ *
+ * @param payload - Envelope to stringify
+ * @param initHeaders - Optional headers merged into the response (plain object or `Headers`)
+ * @param statusOverride - Optional HTTP status override; defaults to `payload.status`
+ * @returns `Response` with `Content-Type: application/json` and body `JSON.stringify(payload)`
+ *
+ * @remarks
+ * When `initHeaders` is a `Headers` instance, entries are copied into a plain object before merge.
+ *
+ * @see {@link withErrorHandling}
+ */
+export function jsonResponse(
+  payload: ApiEnvelope<unknown>,
+  initHeaders?: HeadersInit,
+  statusOverride?: number
+) {
+  const status = statusOverride ?? payload.status
+
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(initHeaders instanceof Headers
+        ? Object.fromEntries(initHeaders.entries())
+        : initHeaders),
+    },
+  })
+}
+
+/**
+ * Appends headers from a secondary source onto a response header collection.
+ *
+ * @param responseHeaders - Mutable `Headers` on the outgoing `Response`
+ * @param authHeaders - Optional headers to append (e.g. `Set-Cookie` from Better Auth)
+ * @returns The same `responseHeaders` instance for chaining
+ *
+ * @remarks
+ * No-op when `authHeaders` is undefined. Uses `append` so multiple `Set-Cookie` values are preserved.
+ *
+ * @see {@link withErrorHandling}
+ */
+export function mergeResponseHeaders(
+  responseHeaders: Headers,
+  authHeaders?: Headers
+) {
+  if (!authHeaders) {
+    return responseHeaders
+  }
+
+  authHeaders.forEach((value, key) => {
+    responseHeaders.append(key, value)
+  })
+
+  return responseHeaders
+}

--- a/src/shared/http/create-api-response-util.ts
+++ b/src/shared/http/create-api-response-util.ts
@@ -97,60 +97,6 @@ export function createErrorResponse(error: unknown): ApiEnvelope<null> {
   }
 }
 
-/**
- * Serializes an API envelope into a JSON {@link Response}.
- *
- * @param payload - Envelope to stringify
- * @param initHeaders - Optional headers merged into the response (plain object or `Headers`)
- * @param statusOverride - Optional HTTP status override; defaults to `payload.status`
- * @returns `Response` with `Content-Type: application/json` and body `JSON.stringify(payload)`
- *
- * @remarks
- * When `initHeaders` is a `Headers` instance, entries are copied into a plain object before merge.
- *
- * @see {@link withErrorHandling}
- */
-export function jsonResponse(
-  payload: ApiEnvelope<unknown>,
-  initHeaders?: HeadersInit,
-  statusOverride?: number
-) {
-  const status = statusOverride ?? payload.status
-
-  return new Response(JSON.stringify(payload), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(initHeaders instanceof Headers
-        ? Object.fromEntries(initHeaders.entries())
-        : initHeaders),
-    },
-  })
-}
-
-/**
- * Appends headers from a secondary source onto a response header collection.
- *
- * @param responseHeaders - Mutable `Headers` on the outgoing `Response`
- * @param authHeaders - Optional headers to append (e.g. `Set-Cookie` from Better Auth)
- * @returns The same `responseHeaders` instance for chaining
- *
- * @remarks
- * No-op when `authHeaders` is undefined. Uses `append` so multiple `Set-Cookie` values are preserved.
- *
- * @see {@link withErrorHandling}
- */
-export function mergeResponseHeaders(
-  responseHeaders: Headers,
-  authHeaders?: Headers
-) {
-  if (!authHeaders) {
-    return responseHeaders
-  }
-
-  authHeaders.forEach((value, key) => {
-    responseHeaders.append(key, value)
-  })
-
-  return responseHeaders
-}
+// Re-exported so consumers importing from `@shared/http/create-api-response-util` keep access to
+// the envelope serialization helpers.
+export * from '@shared/http/api-response-serialize-util'

--- a/src/shared/http/index.ts
+++ b/src/shared/http/index.ts
@@ -14,5 +14,6 @@
  */
 
 export * from './create-api-response-util'
+export * from './api-response-serialize-util'
 export * from './with-error-handling'
 export * from './with-validation'

--- a/src/shared/http/with-error-handling.ts
+++ b/src/shared/http/with-error-handling.ts
@@ -50,8 +50,8 @@ type HandlerResult = {
 /**
  * Astro API route handler function type accepted by {@link withErrorHandling}.
  */
-type RouteHandler = (
-  context: APIContext
+type RouteHandler<TContext extends APIContext = APIContext> = (
+  context: TContext
 ) => Promise<HandlerResult> | HandlerResult
 
 /**
@@ -75,8 +75,10 @@ type RouteHandler = (
  *
  * @see {@link HandlerResult}
  */
-export function withErrorHandling(handler: RouteHandler) {
-  return async (context: APIContext) => {
+export function withErrorHandling<TContext extends APIContext>(
+  handler: RouteHandler<TContext>
+): (context: TContext) => Promise<Response> {
+  return async (context: TContext) => {
     try {
       const result = await handler(context)
       const payload = createSuccessResponse(


### PR DESCRIPTION
This pull request introduces a new, fully documented, and modularized implementation for paginated music list queries in the music domain. It adds a presentational-container pattern for list APIs, including filter normalization, repository queries, mapping, and caching, along with corresponding Zod schemas and improved exports. The changes are organized to support scalable, maintainable, and testable list endpoints.

**Music List Query and Caching System**

* Added a new read-through cache for paginated music list responses, including helpers to build cache keys and store/retrieve results based on normalized filters. [[1]](diffhunk://#diff-4df4bcb716abcb7be1e0a8f5b00b215fcaaefd701aced91f7ad70877c8ed162fR1-R82) [[2]](diffhunk://#diff-2ac2f793a2da42e2f18c9ca16e9f0ba30dd11dc7597cc2567237ccfa31020ff0R17)
* Implemented a repository (`music-list-repository.ts`) for paginated and filtered music list queries, with SQL filter builders and count queries. [[1]](diffhunk://#diff-5bb302a44c50d454e98afeb9cf328a8067385efa196daa72ee6db4dab5d7c29bR1-R134) [[2]](diffhunk://#diff-718602e73410a16ecb2a68c5bfba13cbde1ca048f2c342f39d12440c345d7607R13)
* Introduced filter normalization and mapping utilities to convert raw query parameters into stable, DB-ready filters. [[1]](diffhunk://#diff-5bfc18dbe224bca07647e74f35fd61d2013ff994a8a3fb3347553f63358083f7R1-R72) [[2]](diffhunk://#diff-92ea85fb9a677c33e21d32915bef731c07ba2dcf1cb35d7bf29fc5697476f52eR11-R13)

**Music Card Mapping and Schema**

* Added mappers to convert database music rows and related artists into compact card payloads for list views, and corresponding Zod schemas for validation. [[1]](diffhunk://#diff-630c18750cffe0527f4c50f74fd4c1046aaae85385853fdae352a77f762ddca7R1-R76) [[2]](diffhunk://#diff-0110430087e1a02a616b4356c8a13d2e29e5c65586676d246319ee2a3b14b718R1-R44) [[3]](diffhunk://#diff-92ea85fb9a677c33e21d32915bef731c07ba2dcf1cb35d7bf29fc5697476f52eR11-R13) [[4]](diffhunk://#diff-a0b70bdef1f5d48147292bc736a7410dead6ac366abd96c23c11f1385be883eeR12-R14)

**Repository and Artist Query Enhancements**

* Extended the music relation repository to support batch loading of artists for multiple music records in a single query, improving efficiency for list endpoints. [[1]](diffhunk://#diff-54e4b4572593f838ca1f8e205df48191639ab42afa8c92e0cbe64403474fd9baL8-R8) [[2]](diffhunk://#diff-54e4b4572593f838ca1f8e205df48191639ab42afa8c92e0cbe64403474fd9baR49-R79)

**Documentation and Patterns**

* Added a comprehensive agent guide (`AGENTS.md`) describing the presentational-container pattern, stack, architecture, and key guidelines for the codebase.
* Registered the presentational-container-pattern skill in `skills-lock.json` for documentation and onboarding.