### PR TITLE
Docs/agents guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# AniDev v2 — Agent Guide
+
+## Stack
+- **Runtime**: Bun (primary), Node.js >=22.12.0
+- **Framework**: Astro 6 SSR with `@astrojs/vercel` adapter (`output: 'server'`)
+- **Database**: Turso (LibSQL) via `@libsql/client` + Drizzle ORM
+- **Cache**: Upstash Redis (REST API)
+- **Auth**: Better Auth 1.5.5 (email/password, Drizzle SQLite adapter)
+- **Styling**: Tailwind CSS v4 (`@tailwindcss/vite` plugin)
+- **Monitoring**: Sentry (server + Astro + React; no-ops when `SENTRY_DSN` unset)
+
+## Commands
+| Script | Purpose |
+|--------|---------|
+| `bun run dev` | Astro dev server |
+| `bun run build` | Production build (Vercel output) |
+| `bun run format` | Prettier (semi:false, singleQuote, trailingComma:es5) |
+| `bun run auth:generate` | Generate Better Auth schema (config: `src/lib/auth/server.ts`) |
+| `bun run auth:migrate` | Run Better Auth migrations |
+| `bun run db:generate` | Drizzle migration generation |
+| `bun run db:migrate` | Apply Drizzle migrations |
+| `bun run astro sync` | Regenerate `.astro/types.d.ts` (gitignored, needed after schema changes) |
+| `bun run release:*` | `standard-version` (patch/minor/major/prerelease) |
+
+No test, lint, or typecheck scripts exist. No CI workflows found.
+
+## Architecture (Domain-Driven + Presentational-Container)
+
+### Layered structure
+```
+src/config/     → env validation (Zod, eager at import), site config, public routes
+src/lib/        → infrastructure: auth, db, cache, monitoring
+src/domains/    → business slices: anime/ auth/ media/ music/ user/
+src/pages/      → Astro pages + API routes (file-based routing)
+src/middleware/  → session middleware (auth-middleware.ts, registered in astro.config.mjs)
+src/shared/     → cross-cutting: http/ errors/ schemas/ layouts/ components/ utils/
+```
+
+### Data flow
+```
+DB schema (lib/db/schemas/) → Repository → Mapper → Service → Page/API route
+```
+
+### Presentational-Container pattern
+- **Containers** = Astro page routes (`src/pages/`): fetch data from services, handle errors/redirects, pass data down
+- **Presentational** = Astro SFCs in `src/domains/*/components/`: receive props only, render markup, zero data-fetching
+- **Rule**: *"Data is supplied by domain services in page routes, not fetched inside components"*
+- Each component lives in its own directory: `Name/Name.astro` + `index.ts` barrel
+
+### Domain vertical slice
+Each domain has: `cache/ components/ errors/ mappers/ repositories/ schemas/ services/ types/` (optional: `middleware/`, `policies/`, `utils/`, `config.ts`)
+
+Strict barrel exports at every level.
+
+### Max file size
+**≤150 lines per file.** 17 files currently exceed this (primarily `media/`, `shared/errors/`, and DB schemas) — refactor when touching.
+
+## Path Aliases (tsconfig + Vite)
+`@`, `@styles`, `@domains`, `@shared`, `@lib`, `@config`, `@middleware`, `@layouts`, `@http`, `@components`, `@hooks`, `@stores`, `@utils`, `@db` — all map to `src/` subdirectories. Use these instead of relative imports.
+
+## API Route Patterns
+Two composition styles:
+1. `withZodValidation(schema)(handler)` — validates `{ params, query, body }` as single Zod object, returns 400 on failure
+2. Error handling: `withErrorHandling(handler)` (try/catch wrapper) OR manual try/catch + `mapErrorToHttp(error)`
+
+Response envelope: `{ data, status, error?, meta? }`. Error codes in `src/shared/errors/codes.ts`. HTTP mapping in `src/shared/errors/map-error-to-http.ts`.
+
+## Auth & Middleware
+- **Public routes** (prefix-matched): `/`, `/api/auth/login`, `/api/auth/register`, `/api/anime`, `/api/music`, `/media`
+- Middleware populates `locals.user` / `locals.session` via `resolveAuthActor()` (swallows errors, returns null)
+- For strict auth in API routes: `sessionService.getSession()` throws typed errors
+
+## Environment
+- Validated eagerly at import via Zod in `src/config/env.ts` — missing required vars = immediate crash
+- **Required**: `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`, `BETTER_AUTH_SECRET` (≥32 chars), `BETTER_AUTH_URL`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
+- `APP_BASE_URL` optional, falls back to `BETTER_AUTH_URL`
+
+## Skills & Key Guidelines
+
+| Skill | Key rules for this repo |
+|-------|------------------------|
+| **Clean Code** | Small functions (≤1 screen), single responsibility, meaningful names, no side effects, no boolean params in signatures |
+| **Composition Patterns** | Avoid boolean prop proliferation → compound components; prefer `children` over render props |
+| **React Best Practices** | No barrel imports from large modules; `Promise.all()` for parallel fetches; Suspense boundaries; hoist static I/O; minimize serialization; `React.cache()` for data |
+| **Zod** | `safeParse()` for user input; `z.infer` for type inference; `z.unknown()` not `z.any()`; validate at boundary; `strict()` for incoming data |
+| **Drizzle ORM** | Schema-first with `$inferSelect`/`$inferInsert`; drizzle-kit for migrations; relations for joins |
+| **Better Auth** | Config: `src/lib/auth/server.ts`; client: `authClient` from `src/lib/auth/client.ts`; email/password only |
+| **Tailwind CSS** | Mobile-first; compose utilities over `@apply`; extract repeating patterns as components; CSS variables for themes |
+| **TypeScript** | `z.infer` over manual types; branded types for IDs; discriminated unions for states; `unknown` over `any` |
+| **JSDoc** | Follow existing style (`@module`, `@remarks`, `@see`, `@example`, `@throws`) — codebase is heavily documented |
+| **Frontend Design** | Avoid generic AI aesthetics (no Inter/Roboto, no purple gradients); distinctive typography, asymmetric layouts, CSS variables |
+| **Accessibility** | Semantic HTML, ARIA labels, focus management, skip links, color contrast ≥4.5:1, prefers-reduced-motion |
+| **SEO** | Structured JSON-LD data, OG tags in `base-layout.astro`, canonical URLs, meta descriptions |
+| **Core Web Vitals** | Preload LCP image; `aspect-ratio` for CLS; no tasks >50ms for INP; `font-display: optional` |
+| **Astro** | `astro:middleware` for session; `src/pages/` file-based routing; adapter configures output target |
+
+## Prettier Config
+No semicolons, single quotes, trailing commas es5, 80 print width, arrow parens always. Plugins: `prettier-plugin-astro`, `prettier-plugin-tailwindcss`.
+
+## Important Constraints
+- Better Auth CLI commands are preconfigured with `--config src/lib/auth/server.ts` — do not change path
+- Cache TTL values in **seconds** (`CacheTtl` enum in `src/lib/cache/config.ts`)
+- No `.tsx` React components exist yet (React is configured but unused)
+- No `drizzle.config` found — may need creation for migration generation
+- Auth middleware uses cookie markers (`session_token=`, `session_data=`) — do not rename without updating middleware
+- Sentry no-ops when `SENTRY_DSN` is absent — safe to call `init*` unconditionally
+
+## Commit Convention
+Conventional commits with scopes: `type(scope): summary` (e.g., `fix(auth): Handle expired token`). See `.cursor/commands/commit-all.md`.

--- a/src/domains/music/cache/index.ts
+++ b/src/domains/music/cache/index.ts
@@ -14,3 +14,4 @@
  * ```
  */
 export * from './music-cache'
+export * from './music-list-cache'

--- a/src/domains/music/cache/music-list-cache.ts
+++ b/src/domains/music/cache/music-list-cache.ts
@@ -1,0 +1,82 @@
+/**
+ * Cache helpers for paginated music list responses.
+ *
+ * @module domains/music/cache/music-list-cache
+ * @remarks
+ * Read-through cache for filtered list results from
+ * {@link musicListService.getMusicList}. Key includes the full normalized filter
+ * object (pagination + facets) via `JSON.stringify`.
+ *
+ * **Key format:** `music:list:{JSON.stringify(filters)}`
+ *
+ * **TTL:** `CacheTtl.Medium` (3600 s) — list pages are filter-sensitive; one hour
+ * limits stale pagination totals while avoiding repeated list queries.
+ *
+ * **Null vs miss:** `null` triggers list + count queries; cached value holds
+ * `{ list, total }` even when `list` is empty.
+ *
+ * @see {@link musicListService}
+ * @see {@link mapMusicListFilters}
+ */
+import { cacheGet, cacheSet } from '@lib/cache'
+import { CacheKeyPrefix, CacheTtl } from '@lib/cache/config'
+import type { MusicCard, MusicListFilters } from '@domains/music/types'
+
+/**
+ * Cached payload for a filtered music list query.
+ *
+ * @remarks
+ * Mirrors the return shape of {@link musicListService.getMusicList}.
+ */
+type MusicListCacheValue = {
+  /** Mapped card rows for the current page */
+  list: MusicCard[]
+  /** Total rows matching filters (all pages) */
+  total: number
+}
+
+/**
+ * Read-through cache for paginated music list results keyed by filter set.
+ */
+export const musicListCache = {
+  /**
+   * Builds the Redis cache key for a music list query.
+   *
+   * @param filters - Normalized {@link MusicListFilters}
+   * @returns `music:list:` + stable JSON of filters (property order matters)
+   *
+   * @example
+   * ```typescript
+   * musicListCache.key({ page: 1, limit: 10, type: 'OP' })
+   * // 'music:list:{"page":1,"limit":10,"type":"OP"}'
+   * ```
+   */
+  key(filters: MusicListFilters) {
+    return `${CacheKeyPrefix.MusicList}:${JSON.stringify(filters)}`
+  },
+
+  /**
+   * Retrieves a cached music list result.
+   *
+   * @param filters - Same normalized filters used for `key`
+   * @returns `{ list, total }` on hit, `null` on miss
+   */
+  async get(filters: MusicListFilters): Promise<MusicListCacheValue | null> {
+    return cacheGet<MusicListCacheValue>(this.key(filters))
+  },
+
+  /**
+   * Stores a paginated music list result in Redis.
+   *
+   * @param filters - Normalized filters
+   * @param value - Cards for current page and total count
+   */
+  async set(
+    filters: MusicListFilters,
+    value: MusicListCacheValue
+  ): Promise<void> {
+    return cacheSet<MusicListCacheValue>(this.key(filters), value, {
+      ttlSeconds: CacheTtl.Medium,
+    })
+  },
+}

--- a/src/domains/music/mappers/index.ts
+++ b/src/domains/music/mappers/index.ts
@@ -8,4 +8,6 @@
  * import { mapMusicDetail } from '@domains/music/mappers'
  * ```
  */
+export * from './music-card-mapper'
 export * from './music-detail-mapper'
+export * from './music-filters-mapper'

--- a/src/domains/music/mappers/music-card-mapper.ts
+++ b/src/domains/music/mappers/music-card-mapper.ts
@@ -1,0 +1,76 @@
+/**
+ * Maps database music rows into card payloads for list views.
+ *
+ * @module domains/music/mappers/music-card-mapper
+ */
+import type { MusicDB, MusicArtistDB } from '@domains/music/types/music-db.d-types'
+import type { MusicCard } from '@domains/music/types/music-card.d-types'
+
+/** Input for mapping a single music row to a card. */
+type MapMusicCardInput = {
+  music: MusicDB
+  artists: MusicArtistDB[]
+}
+
+/** Input for mapping multiple music rows to cards. */
+type MapMusicListToCardsInput = {
+  musicList: MusicDB[]
+  artistsByMusicId: Record<number, MusicArtistDB[]>
+}
+
+/**
+ * Maps a single music database row into a {@link MusicCard}.
+ *
+ * @param input - Music row plus linked artists
+ * @returns Compact card with type labels and artist credits
+ *
+ * @remarks
+ * - `type` / `typeCode` normalize DB codes (`OP`, `ED`, `UNK`)
+ * - Missing titles default to `'Unknown Title'`
+ *
+ * @see {@link musicCardSchema}
+ */
+export const mapMusicCard = ({
+  music,
+  artists,
+}: MapMusicCardInput): MusicCard => {
+  const typeCode: MusicCard['typeCode'] =
+    music.type === 'OP' || music.type === 'ED' || music.type === 'UNK'
+      ? music.type
+      : 'UNK'
+
+  let type: MusicCard['type'] = 'unknown'
+  if (typeCode === 'OP') type = 'opening'
+  else if (typeCode === 'ED') type = 'ending'
+
+  return {
+    id: music.id,
+    title: music.title ?? 'Unknown Title',
+    type,
+    typeCode,
+    artists: artists.map((a) => ({
+      name: a.name ?? 'Unknown Artist',
+      malId: a.malId ?? 0,
+    })),
+  }
+}
+
+/**
+ * Maps a collection of music rows into card payloads.
+ *
+ * @param input - Music rows for one list page and artists grouped by music ID
+ * @returns {@link MusicCard}[] in repository order
+ *
+ * @see {@link musicListService}
+ */
+export const mapMusicListToCards = ({
+  musicList,
+  artistsByMusicId,
+}: MapMusicListToCardsInput): MusicCard[] => {
+  return musicList.map((music) =>
+    mapMusicCard({
+      music,
+      artists: artistsByMusicId[music.id] ?? [],
+    })
+  )
+}

--- a/src/domains/music/mappers/music-filters-mapper.ts
+++ b/src/domains/music/mappers/music-filters-mapper.ts
@@ -1,0 +1,72 @@
+/**
+ * Maps raw list query parameters into normalized filter objects.
+ *
+ * @module domains/music/mappers/music-filters-mapper
+ */
+import type {
+  MusicListFilters,
+  MusicListFiltersParams,
+} from '@domains/music/types'
+
+const TYPE_CODE_BY_LABEL: Record<string, MusicListFilters['type']> = {
+  opening: 'OP',
+  ending: 'ED',
+  unknown: 'UNK',
+  op: 'OP',
+  ed: 'ED',
+  unk: 'UNK',
+  OP: 'OP',
+  ED: 'ED',
+  UNK: 'UNK',
+}
+
+/**
+ * Coerces a raw type query value to a database type code.
+ *
+ * @internal
+ */
+const normalizeType = (
+  raw?: string
+): MusicListFilters['type'] | undefined => {
+  const trimmed = raw?.trim()
+  if (!trimmed) return undefined
+
+  const fromMap =
+    TYPE_CODE_BY_LABEL[trimmed] ?? TYPE_CODE_BY_LABEL[trimmed.toLowerCase()]
+  if (fromMap) return fromMap
+
+  if (trimmed === 'OP' || trimmed === 'ED' || trimmed === 'UNK') {
+    return trimmed
+  }
+
+  return undefined
+}
+
+/**
+ * Normalizes request query parameters into repository-ready filters.
+ *
+ * @param params - Raw query from {@link musicListFiltersParamsSchema}
+ * @returns {@link MusicListFilters} with DB `type` codes when a type filter is present
+ *
+ * @remarks
+ * Used by {@link musicListService} for repository queries and
+ * {@link musicListCache.key} (must stay stable for cache hits).
+ *
+ * @example
+ * ```typescript
+ * mapMusicListFilters({ page: 1, limit: 10, type: 'opening' })
+ * // { page: 1, limit: 10, type: 'OP', ... }
+ * ```
+ *
+ * @see {@link buildMusicListFilters}
+ */
+export const mapMusicListFilters = (
+  params: MusicListFiltersParams
+): MusicListFilters => {
+  return {
+    page: params.page,
+    limit: params.limit,
+    type: normalizeType(params.type),
+    query: params.query?.trim() || undefined,
+  }
+}

--- a/src/domains/music/repositories/index.ts
+++ b/src/domains/music/repositories/index.ts
@@ -10,6 +10,7 @@
  * ```
  */
 export * from './anime-music-repository'
+export * from './music-list-repository'
 export * from './music-relation-repository'
 export * from './music-repository'
 export * from './music-version-repository'

--- a/src/domains/music/repositories/music-list-repository.ts
+++ b/src/domains/music/repositories/music-list-repository.ts
@@ -1,0 +1,134 @@
+/**
+ * Data access and filter builders for paginated music list queries.
+ *
+ * @module domains/music/repositories/music-list-repository
+ */
+import { db } from '@db/client'
+import { music } from '@db/schemas/music'
+import { dbError } from '@shared/errors/db-errors'
+import { normalizeString } from '@utils/string/normalize-string-util'
+import type { MusicDB, MusicListFilters } from '@domains/music/types'
+import { and, count, eq, sql, type SQL } from 'drizzle-orm'
+
+/**
+ * Filter fields used to build SQL `WHERE` clauses (excludes pagination).
+ */
+type MusicListFilterParams = Omit<MusicListFilters, 'page' | 'limit'>
+
+/**
+ * Builds SQL filter clauses for music list queries.
+ *
+ * @param filterParams - Normalized filter values excluding `page` / `limit`
+ * @returns Array of Drizzle `SQL` fragments combined with `AND`
+ *
+ * @remarks
+ * | Filter | Column | Behavior |
+ * |--------|--------|----------|
+ * | `type` | `music.type` | equality (`OP`, `ED`, `UNK`) |
+ * | `query` | `music.title` | normalized `LIKE` (spaces stripped, lowercased) |
+ *
+ * @see {@link mapMusicListFilters}
+ * @see {@link musicListRepository.getMusicList}
+ */
+export const buildMusicListFilters = ({
+  type,
+  query,
+}: MusicListFilterParams): SQL[] => {
+  const filters: SQL[] = []
+
+  if (type) {
+    filters.push(eq(music.type, type))
+  }
+
+  if (query?.trim()) {
+    const normalizedQuery = normalizeString({
+      string: query,
+      removeSpaces: true,
+      separator: '',
+      toLowerCase: true,
+    })
+
+    const queryPattern = `%${normalizedQuery}%`
+    const normalizedTitle = sql`REPLACE(LOWER(COALESCE(${music.title}, '')), ' ', '')`
+
+    filters.push(sql`${normalizedTitle} LIKE ${queryPattern}`)
+  }
+
+  return filters
+}
+
+/**
+ * Repository for querying filtered and paginated music lists.
+ *
+ * @remarks
+ * **Table:** `music`
+ *
+ * **SQL:** `SELECT *` with `LIMIT` / `OFFSET`; count uses `count()`.
+ *
+ * @see {@link musicListService}
+ * @see {@link mapMusicListToCards}
+ */
+export const musicListRepository = {
+  /**
+   * Loads a paginated music list matching the provided filters.
+   *
+   * @param filters - {@link MusicListFilters} including `page`, `limit`, and facets
+   * @returns {@link MusicDB} rows for the current page
+   *
+   * @throws {DbError} On database failure
+   *
+   * @example
+   * ```typescript
+   * const rows = await musicListRepository.getMusicList({
+   *   page: 1, limit: 20, type: 'OP',
+   * })
+   * ```
+   */
+  async getMusicList({
+    page,
+    limit,
+    ...filterParams
+  }: MusicListFilters): Promise<MusicDB[]> {
+    try {
+      const whereConditions = buildMusicListFilters(filterParams)
+
+      return await db
+        .select()
+        .from(music)
+        .where(
+          whereConditions.length > 0 ? and(...whereConditions) : undefined
+        )
+        .limit(limit)
+        .offset((page - 1) * limit)
+    } catch (error) {
+      throw dbError('getMusicList', { page, limit, ...filterParams }, error)
+    }
+  },
+
+  /**
+   * Counts music rows matching the provided filters.
+   *
+   * @param filterParams - Filters without pagination
+   * @returns Total matching count (`0` when none)
+   *
+   * @throws {DbError} On database failure
+   */
+  async getMusicListCount(
+    filterParams: MusicListFilterParams
+  ): Promise<number> {
+    try {
+      const whereConditions = buildMusicListFilters(filterParams)
+
+      const [result] = await db
+        .select({ count: count() })
+        .from(music)
+        .where(
+          whereConditions.length > 0 ? and(...whereConditions) : undefined
+        )
+
+      return result?.count ?? 0
+    } catch (error) {
+      throw dbError('getMusicListCount', filterParams, error)
+    }
+  },
+}

--- a/src/domains/music/repositories/music-relation-repository.ts
+++ b/src/domains/music/repositories/music-relation-repository.ts
@@ -5,7 +5,7 @@
 import { db } from '@db/client'
 import { musicArtist } from '@db/schemas/music-relations'
 import { artist } from '@db/schemas/artist'
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import type { MusicArtistDB } from '@domains/music/types/music-db.d-types'
 
 /**
@@ -43,6 +43,37 @@ export const musicRelationRepository = {
       .from(musicArtist)
       .innerJoin(artist, eq(musicArtist.artistId, artist.id))
       .where(eq(musicArtist.musicId, musicId))
+
+    return rows
+  },
+
+  /**
+   * Loads artists linked to multiple music records in one query.
+   *
+   * @param musicIds - Internal music identifiers
+   * @returns {@link MusicArtistDB} rows with `musicId` for grouping in list mappers
+   * @remarks Short-circuits to an empty array when `musicIds` is empty.
+   * @see {@link musicListService.getMusicList} for batch usage
+   * @example
+   * ```typescript
+   * const artists = await musicRelationRepository.findArtistsByMusicIds([1, 2, 3])
+   * ```
+   */
+  async findArtistsByMusicIds(
+    musicIds: number[]
+  ): Promise<Array<MusicArtistDB & { musicId: number }>> {
+    if (musicIds.length === 0) return []
+
+    const rows = await db
+      .select({
+        id: musicArtist.artistId,
+        name: artist.name,
+        malId: artist.malId,
+        musicId: musicArtist.musicId,
+      })
+      .from(musicArtist)
+      .innerJoin(artist, eq(musicArtist.artistId, artist.id))
+      .where(inArray(musicArtist.musicId, musicIds))
 
     return rows
   },

--- a/src/domains/music/schemas/index.ts
+++ b/src/domains/music/schemas/index.ts
@@ -9,4 +9,6 @@
  * ```
  */
 export * from './api-schema'
+export * from './music-card-schema'
 export * from './music-details-schema'
+export * from './music-list-schema'

--- a/src/domains/music/schemas/music-card-schema.ts
+++ b/src/domains/music/schemas/music-card-schema.ts
@@ -1,0 +1,44 @@
+/**
+ * Zod schemas for music card API payloads.
+ *
+ * @module domains/music/schemas/music-card-schema
+ * @remarks
+ * **Response schema** — validates mapped list/card DTOs from {@link mapMusicCard}.
+ */
+import { z } from 'zod'
+
+/**
+ * Validates an artist entry on a music card payload.
+ *
+ * @remarks
+ * | Field | Rule |
+ * |-------|------|
+ * | `name` | `z.string()` |
+ * | `malId` | `z.number()` |
+ */
+export const musicCardArtistSchema = z.object({
+  name: z.string(),
+  malId: z.number(),
+})
+
+/**
+ * Validates a compact music card shown in list views.
+ *
+ * @remarks
+ * | Field | Rule |
+ * |-------|------|
+ * | `id` | `z.number()` — internal music ID |
+ * | `title` | `z.string()` |
+ * | `type` | `'opening' \| 'ending' \| 'unknown'` |
+ * | `typeCode` | `'OP' \| 'ED' \| 'UNK'` |
+ * | `artists` | array of {@link musicCardArtistSchema} |
+ *
+ * @see {@link mapMusicCard}
+ */
+export const musicCardSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  type: z.enum(['opening', 'ending', 'unknown']),
+  typeCode: z.enum(['OP', 'ED', 'UNK']),
+  artists: z.array(musicCardArtistSchema),
+})

--- a/src/domains/music/schemas/music-list-schema.ts
+++ b/src/domains/music/schemas/music-list-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Zod schemas for music list and filter API payloads.
+ *
+ * @module domains/music/schemas/music-list-schema
+ */
+import { createApiResponseSchema } from '@shared/schemas/api-schema'
+import { musicCardSchema } from '@domains/music/schemas/music-card-schema'
+import { z } from 'zod'
+
+/**
+ * **Request query schema** — raw query parameters for music list requests.
+ *
+ * @remarks
+ * | Field | Validation |
+ * |-------|------------|
+ * | `page` | `z.coerce.number().int().min(1).default(1)` |
+ * | `limit` | `z.coerce.number().int().min(1).max(100).default(10)` |
+ * | `type` | optional string — `OP`, `ED`, `UNK`, or labels `opening` / `ending` (normalized in mapper) |
+ * | `query` | optional search string (title substring) |
+ */
+export const musicListFiltersParamsSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+  type: z.string().optional(),
+  query: z.string().optional(),
+})
+
+/**
+ * **Normalized filters** — after {@link mapMusicListFilters}; used by repos and cache keys.
+ */
+export const musicListFiltersSchema = musicListFiltersParamsSchema.extend({
+  type: z.enum(['OP', 'ED', 'UNK']).optional(),
+})
+
+/**
+ * **Full request schema** for `GET /api/music` (list).
+ */
+export const musicListRequestSchema = z.object({
+  params: z.object({}).optional().default({}),
+  query: musicListFiltersParamsSchema,
+  body: z.unknown().optional(),
+})
+
+/**
+ * **Response schema** — paginated cards (total count returned separately by route).
+ */
+export const musicListResponseSchema = createApiResponseSchema(
+  z.array(musicCardSchema)
+)

--- a/src/domains/music/services/index.ts
+++ b/src/domains/music/services/index.ts
@@ -3,9 +3,11 @@
  * @remarks Barrel exports for music application services that orchestrate repositories,
  * mappers, and cache layers.
  * @see {@link ./music-service} for music detail reads
+ * @see {@link ./music-list-service} for paginated list reads
  * @example
  * ```typescript
- * import { musicService } from '@domains/music/services'
+ * import { musicService, musicListService } from '@domains/music/services'
  * ```
  */
+export * from './music-list-service'
 export * from './music-service'

--- a/src/domains/music/services/music-list-service.ts
+++ b/src/domains/music/services/music-list-service.ts
@@ -1,0 +1,96 @@
+/**
+ * Application service for paginated music list data.
+ *
+ * @module domains/music/services/music-list-service
+ */
+import { withCache } from '@lib/cache'
+import { musicListCache } from '@domains/music/cache/music-list-cache'
+import { mapMusicListToCards } from '@domains/music/mappers/music-card-mapper'
+import { mapMusicListFilters } from '@domains/music/mappers/music-filters-mapper'
+import { musicListRepository } from '@domains/music/repositories/music-list-repository'
+import { musicRelationRepository } from '@domains/music/repositories/music-relation-repository'
+import type {
+  MusicArtistDB,
+  MusicCard,
+  MusicListFilters,
+  MusicListFiltersParams,
+} from '@domains/music/types'
+
+/**
+ * Groups artist rows by parent music ID for card mapping.
+ *
+ * @internal
+ */
+const groupArtistsByMusicId = (
+  artists: Array<MusicArtistDB & { musicId: number }>
+): Record<number, MusicArtistDB[]> => {
+  return artists.reduce<Record<number, MusicArtistDB[]>>((acc, row) => {
+    const { musicId, ...artist } = row
+    if (!acc[musicId]) {
+      acc[musicId] = []
+    }
+    acc[musicId].push(artist)
+    return acc
+  }, {})
+}
+
+/**
+ * Coordinates repository access, mapping, and caching for music list pages.
+ *
+ * @remarks
+ * **Pipeline:** `mapMusicListFilters(params)` → `music:list:{JSON}` → list + count
+ * repos → batch artists → `mapMusicListToCards` → `{ list, total }`
+ *
+ * **Cache TTL:** {@link CacheTtl.Medium} (3600 s)
+ *
+ * @see {@link musicListCache}
+ */
+export const musicListService = {
+  /**
+   * Loads a filtered, paginated music list with total count.
+   *
+   * @param filtersParams - Raw query parameters (coerced by Zod at the route)
+   * @returns `{ list: MusicCard[], total: number }` for the current filter page
+   *
+   * @throws {InfraError} On repository or cache failures
+   *
+   * @example
+   * ```typescript
+   * const { list, total } = await musicListService.getMusicList({
+   *   page: 1, limit: 10, type: 'OP',
+   * })
+   * ```
+   */
+  async getMusicList(
+    filtersParams: MusicListFiltersParams
+  ): Promise<{ list: MusicCard[]; total: number }> {
+    const filters: MusicListFilters = mapMusicListFilters(filtersParams)
+
+    return withCache({
+      key: musicListCache.key(filters),
+      getCache: () => musicListCache.get(filters),
+      setCache: (_, value) => musicListCache.set(filters, value),
+      compute: async () => {
+        const [musicList, total] = await Promise.all([
+          musicListRepository.getMusicList(filters),
+          musicListRepository.getMusicListCount(filters),
+        ])
+
+        if (musicList.length === 0) {
+          return { list: [], total }
+        }
+
+        const musicIds = musicList.map((m) => m.id)
+        const artists =
+          await musicRelationRepository.findArtistsByMusicIds(musicIds)
+
+        const list = mapMusicListToCards({
+          musicList,
+          artistsByMusicId: groupArtistsByMusicId(artists),
+        })
+
+        return { list, total }
+      },
+    })
+  },
+}

--- a/src/domains/music/types/index.ts
+++ b/src/domains/music/types/index.ts
@@ -11,3 +11,5 @@
  */
 export * from './music-db.d-types'
 export * from './music-details.d-types'
+export * from './music-card.d-types'
+export * from './music-list.d-types'

--- a/src/domains/music/types/music-card.d-types.ts
+++ b/src/domains/music/types/music-card.d-types.ts
@@ -1,0 +1,17 @@
+/**
+ * Domain types for music card payloads.
+ *
+ * @module domains/music/types/music-card
+ */
+import { z } from 'zod'
+import { musicCardSchema } from '@domains/music/schemas/music-card-schema'
+
+/**
+ * Compact music summary used in list views.
+ *
+ * @remarks
+ * Inferred from {@link musicCardSchema}. Produced by {@link mapMusicCard}.
+ *
+ * @see {@link MusicListResponse}
+ */
+export type MusicCard = z.infer<typeof musicCardSchema>

--- a/src/domains/music/types/music-list.d-types.ts
+++ b/src/domains/music/types/music-list.d-types.ts
@@ -1,0 +1,36 @@
+/**
+ * Domain types for music list and filter payloads.
+ *
+ * @module domains/music/types/music-list
+ */
+import {
+  musicListFiltersParamsSchema,
+  musicListFiltersSchema,
+  musicListResponseSchema,
+} from '@domains/music/schemas/music-list-schema'
+import { z } from 'zod'
+
+/**
+ * Normalized list filters used by repositories and cache keys.
+ *
+ * @remarks
+ * `type` is normalized to DB codes (`OP`, `ED`, `UNK`) via {@link mapMusicListFilters}.
+ *
+ * @see {@link musicListRepository}
+ * @see {@link musicListCache}
+ */
+export type MusicListFilters = z.infer<typeof musicListFiltersSchema>
+
+/**
+ * Raw query parameters for music list requests (pre-mapper).
+ *
+ * @see {@link musicListFiltersParamsSchema}
+ */
+export type MusicListFiltersParams = z.infer<
+  typeof musicListFiltersParamsSchema
+>
+
+/**
+ * API response wrapping a paginated music card array.
+ */
+export type MusicListResponse = z.infer<typeof musicListResponseSchema>

--- a/src/lib/cache/config.ts
+++ b/src/lib/cache/config.ts
@@ -42,6 +42,9 @@ export enum CacheKeyPrefix {
   /** Music track detail payloads. Value: `'music:details'`. */
   MusicDetails = 'music:details',
 
+  /** Paginated or filtered music list responses. Value: `'music:list'`. */
+  MusicList = 'music:list',
+
   /** Extended user profile preferences and display fields. Value: `'user:profile'`. */
   UserProfile = 'user:profile',
 }

--- a/src/pages/api/music/index.ts
+++ b/src/pages/api/music/index.ts
@@ -1,0 +1,116 @@
+/**
+ * Paginated music list API endpoint.
+ *
+ * @module pages/api/music/index
+ *
+ * **Route:** `GET /api/music`
+ *
+ * **Authentication:** Public — no session required ({@link isPublicRoute} allowlists `/api/music`).
+ *
+ * Returns a filtered, paginated list of music cards for browse and search flows.
+ *
+ * @see {@link musicListRequestSchema} — request validation schema
+ * @see {@link musicListResponseSchema} — response validation schema
+ * @see {@link musicListService.getMusicList} — list query service
+ * @see {@link mapErrorToHttp} — error-to-HTTP mapping
+ */
+
+import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
+import { withZodValidation } from '@http/with-validation'
+import {
+  musicListRequestSchema,
+  musicListResponseSchema,
+} from '@domains/music/schemas/music-list-schema'
+import { musicListService } from '@domains/music/services/music-list-service'
+import type { APIRoute } from 'astro'
+
+/**
+ * Returns a paginated, filterable music card list.
+ *
+ * @remarks
+ * **Request**
+ *
+ * | Source | Field | Type | Required | Default | Description |
+ * |--------|-------|------|----------|---------|-------------|
+ * | Query | `page` | `number` | No | `1` | Page number (integer ≥ 1) |
+ * | Query | `limit` | `number` | No | `10` | Page size (integer 1–100) |
+ * | Query | `type` | `string` | No | — | Music type: `OP`, `ED`, `UNK`, or labels `opening` / `ending` |
+ * | Query | `query` | `string` | No | — | Free-text search on title |
+ *
+ * **Success response — `200 OK`**
+ *
+ * ```typescript
+ * {
+ *   data: Array<{
+ *     id: number
+ *     title: string
+ *     type: 'opening' | 'ending' | 'unknown'
+ *     typeCode: 'OP' | 'ED' | 'UNK'
+ *     artists: Array<{ name: string; malId: number }>
+ *   }>
+ *   status: 200
+ *   meta: {
+ *     page: number
+ *     total: number
+ *     hasNext: boolean
+ *   }
+ * }
+ * ```
+ *
+ * **Error responses** (JSON envelope: `{ data: null, status, error, meta }`)
+ *
+ * | Status | Code | When |
+ * |--------|------|------|
+ * | 400 | `VALIDATION_ERROR` | Query params fail {@link musicListRequestSchema} validation |
+ * | 500 | `DB_ERROR` | Database query failed |
+ * | 500 | `CACHE_ERROR` | Cache read/write failure |
+ * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ *
+ * @example
+ * ```bash
+ * curl "http://localhost:4321/api/music?page=1&limit=20&type=OP&query=unravel"
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const res = await fetch('/api/music?page=1&limit=10&type=opening')
+ * const { data, meta } = await res.json()
+ * // data: MusicCard[], meta: { page, total, hasNext }
+ * ```
+ */
+export const GET: APIRoute = withZodValidation(musicListRequestSchema)(async ({
+  validated,
+}) => {
+  try {
+    const { list: musicCards, total } = await musicListService.getMusicList(
+      validated.query
+    )
+    const payload = {
+      data: musicCards,
+      status: 200,
+      meta: {
+        page: validated.query.page,
+        total,
+        hasNext: validated.query.page * validated.query.limit < total,
+      },
+    }
+    const responseBody = musicListResponseSchema.parse(payload)
+
+    return new Response(JSON.stringify(responseBody), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    const { status, body } = mapErrorToHttp(error)
+    const payload = {
+      data: null,
+      status,
+      error: body.message ?? 'Unexpected error',
+      meta: body.meta ?? {},
+    }
+
+    return new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+})


### PR DESCRIPTION
This pull request introduces a comprehensive, domain-driven architecture for paginated music list queries in the music domain. It adds new cache, repository, mapping, and schema modules to efficiently support filtered, paginated music list endpoints, along with detailed documentation and code organization improvements.

**Key changes:**

### Music List Query Architecture

- Introduced `music-list-repository` for paginated, filtered music list SQL queries and counting, using normalized filters and robust error handling. (`src/domains/music/repositories/music-list-repository.ts`)
- Added `music-list-cache` module for read-through caching of paginated music list results, keyed by normalized filters and with a one-hour TTL. (`src/domains/music/cache/music-list-cache.ts`)
- Updated cache and repository `index.ts` files to export new modules. (`src/domains/music/cache/index.ts`, `src/domains/music/repositories/index.ts`) [[1]](diffhunk://#diff-2ac2f793a2da42e2f18c9ca16e9f0ba30dd11dc7597cc2567237ccfa31020ff0R17) [[2]](diffhunk://#diff-718602e73410a16ecb2a68c5bfba13cbde1ca048f2c342f39d12440c345d7607R13)

### Data Mapping & Schemas

- Added `music-card-mapper` and `music-filters-mapper` to map DB rows and query params into normalized API payloads and filter objects. (`src/domains/music/mappers/music-card-mapper.ts`, `src/domains/music/mappers/music-filters-mapper.ts`) [[1]](diffhunk://#diff-630c18750cffe0527f4c50f74fd4c1046aaae85385853fdae352a77f762ddca7R1-R76) [[2]](diffhunk://#diff-5bfc18dbe224bca07647e74f35fd61d2013ff994a8a3fb3347553f63358083f7R1-R72)
- Introduced Zod schemas for music card and music list API payloads, including request, response, and filter validation. (`src/domains/music/schemas/music-card-schema.ts`, `src/domains/music/schemas/music-list-schema.ts`) [[1]](diffhunk://#diff-0110430087e1a02a616b4356c8a13d2e29e5c65586676d246319ee2a3b14b718R1-R44) [[2]](diffhunk://#diff-c53b89187fbdb199b34bb319483d73847e7d8fa2d028d8f8ae864f5ef5893336R1-R49)
- Updated mappers and schemas `index.ts` files to export new modules. (`src/domains/music/mappers/index.ts`, `src/domains/music/schemas/index.ts`) [[1]](diffhunk://#diff-92ea85fb9a677c33e21d32915bef731c07ba2dcf1cb35d7bf29fc5697476f52eR11-R13) [[2]](diffhunk://#diff-a0b70bdef1f5d48147292bc736a7410dead6ac366abd96c23c11f1385be883eeR12-R14)

### Repository Enhancements

- Added `findArtistsByMusicIds` to `musicRelationRepository` for batch loading artists for multiple music records in a single query, improving efficiency in list endpoints. (`src/domains/music/repositories/music-relation-repository.ts`) [[1]](diffhunk://#diff-54e4b4572593f838ca1f8e205df48191639ab42afa8c92e0cbe64403474fd9baR49-R79) [[2]](diffhunk://#diff-54e4b4572593f838ca1f8e205df48191639ab42afa8c92e0cbe64403474fd9baL8-R8)

### Documentation

- Added a comprehensive `AGENTS.md` guide detailing the stack, architecture, coding standards, file structure, and key conventions for the project, facilitating onboarding and consistency. (`AGENTS.md`)