### PR TITLE
refactor(user): Split errors, policies, and schemas

### DIFF
--- a/src/domains/user/errors/index.ts
+++ b/src/domains/user/errors/index.ts
@@ -13,4 +13,5 @@
  * throw userNotFound('user-123')
  * ```
  */
+export * from './user-error-classes'
 export * from './user-not-found-error'

--- a/src/domains/user/errors/user-error-classes.ts
+++ b/src/domains/user/errors/user-error-classes.ts
@@ -1,0 +1,122 @@
+/**
+ * Error classes for user lookup and authorization failures.
+ *
+ * @module domains/user/errors/user-error-classes
+ * @remarks
+ * Extend shared base classes ({@link DomainError}, {@link ValidationError}, {@link AuthError})
+ * and carry stable {@link ErrorCodes} values for consistent HTTP mapping. Factory helpers in
+ * {@link user-not-found-error} wrap construction.
+ */
+import {
+  AuthError,
+  DomainError,
+  ValidationError,
+} from '@shared/errors/app-error'
+import { ErrorCodes } from '@shared/errors/codes'
+
+/**
+ * Thrown when no user profile exists for the given identifier.
+ *
+ * @remarks
+ * Indicates the target user ID was syntactically valid but did not match a
+ * persisted profile row. Distinct from {@link UserInvalidIdError}, which
+ * covers malformed route or query parameters.
+ * @see {@link userNotFound} for the factory helper
+ * @see {@link userService.getUserProfile} where this error is raised
+ * @example
+ * ```typescript
+ * if (!userProfileDB) {
+ *   throw userNotFound(targetId)
+ * }
+ * ```
+ */
+export class UserNotFoundError extends DomainError {
+  /**
+   * Creates a not-found error for a missing user profile.
+   *
+   * @param id - User identifier that was not found
+   * @returns A configured {@link UserNotFoundError} instance
+   * @remarks
+   * The identifier is attached to error metadata for logging and client
+   * diagnostics under the {@link ErrorCodes.USER_NOT_FOUND} code.
+   * @see {@link ErrorCodes.USER_NOT_FOUND}
+   * @example
+   * ```typescript
+   * throw new UserNotFoundError('550e8400-e29b-41d4-a716-446655440000')
+   * ```
+   */
+  constructor(id: string) {
+    super(ErrorCodes.USER_NOT_FOUND, 'User not found', { id })
+  }
+}
+
+/**
+ * Thrown when a route or query parameter is not a valid user identifier.
+ *
+ * @remarks
+ * Used at validation boundaries before authorization or persistence access.
+ * The raw, unparsed value is preserved in metadata to aid debugging.
+ * @see {@link userInvalidId} for the factory helper
+ * @example
+ * ```typescript
+ * const parsed = getUserProfileSchema.safeParse(request)
+ * if (!parsed.success) {
+ *   throw userInvalidId(request.params.userId)
+ * }
+ * ```
+ */
+export class UserInvalidIdError extends ValidationError {
+  /**
+   * Creates a validation error for an invalid user identifier.
+   *
+   * @param rawId - Unparsed identifier from the request
+   * @returns A configured {@link UserInvalidIdError} instance
+   * @remarks
+   * Accepts `unknown` because invalid IDs may arrive as numbers, empty
+   * strings, or other non-string shapes from route parameters.
+   * @see {@link ErrorCodes.USER_INVALID_ID}
+   * @example
+   * ```typescript
+   * throw new UserInvalidIdError(undefined)
+   * ```
+   */
+  constructor(rawId: unknown) {
+    super(ErrorCodes.USER_INVALID_ID, 'Invalid user id', { rawId })
+  }
+}
+
+/**
+ * Thrown when the caller lacks permission to access a user resource.
+ *
+ * @remarks
+ * Raised after policy evaluation denies access—for example when a user
+ * attempts to view private preferences or history belonging to another
+ * account. Public profile reads currently pass policy checks.
+ * @see {@link userUnauthorized} for the factory helper
+ * @see {@link userPolicies} for authorization rules
+ * @example
+ * ```typescript
+ * if (!userPolicies.canViewUserPreferences({ userId, targetId })) {
+ *   throw userUnauthorized(targetId)
+ * }
+ * ```
+ */
+export class UserUnauthorizedError extends AuthError {
+  /**
+   * Creates an authorization error for a denied access attempt.
+   *
+   * @param userId - User identifier that was denied access
+   * @returns A configured {@link UserUnauthorizedError} instance
+   * @remarks
+   * Stores the denied resource owner ID in metadata under
+   * {@link ErrorCodes.USER_UNAUTHORIZED}.
+   * @see {@link ErrorCodes.USER_UNAUTHORIZED}
+   * @example
+   * ```typescript
+   * throw new UserUnauthorizedError('other-user-id')
+   * ```
+   */
+  constructor(userId: string) {
+    super(ErrorCodes.USER_UNAUTHORIZED, 'Unauthorized user', { userId })
+  }
+}

--- a/src/domains/user/errors/user-not-found-error.ts
+++ b/src/domains/user/errors/user-not-found-error.ts
@@ -1,122 +1,19 @@
 /**
- * Domain errors raised for user lookup and authorization failures.
+ * Factory helpers for user lookup and authorization domain errors.
  *
  * @module domains/user/errors/user-not-found-error
  * @remarks
- * These errors extend shared base classes ({@link DomainError},
- * {@link ValidationError}, {@link AuthError}) and carry stable
- * {@link ErrorCodes} values for consistent HTTP mapping. Factory helpers
- * return instances so callers can `throw` them from services or route handlers.
+ * Factories return error instances so callers can `throw` them from services or route handlers.
+ * The error classes themselves live in {@link user-error-classes} and are re-exported here so
+ * existing `@domains/user/errors/user-not-found-error` imports keep working.
  */
-import { AuthError, DomainError, ValidationError } from '@shared/errors/app-error'
-import { ErrorCodes } from '@shared/errors/codes'
+import {
+  UserInvalidIdError,
+  UserNotFoundError,
+  UserUnauthorizedError,
+} from '@domains/user/errors/user-error-classes'
 
-/**
- * Thrown when no user profile exists for the given identifier.
- *
- * @remarks
- * Indicates the target user ID was syntactically valid but did not match a
- * persisted profile row. Distinct from {@link UserInvalidIdError}, which
- * covers malformed route or query parameters.
- * @see {@link userNotFound} for the factory helper
- * @see {@link userService.getUserProfile} where this error is raised
- * @example
- * ```typescript
- * if (!userProfileDB) {
- *   throw userNotFound(targetId)
- * }
- * ```
- */
-export class UserNotFoundError extends DomainError {
-  /**
-   * Creates a not-found error for a missing user profile.
-   *
-   * @param id - User identifier that was not found
-   * @returns A configured {@link UserNotFoundError} instance
-   * @remarks
-   * The identifier is attached to error metadata for logging and client
-   * diagnostics under the {@link ErrorCodes.USER_NOT_FOUND} code.
-   * @see {@link ErrorCodes.USER_NOT_FOUND}
-   * @example
-   * ```typescript
-   * throw new UserNotFoundError('550e8400-e29b-41d4-a716-446655440000')
-   * ```
-   */
-  constructor(id: string) {
-    super(ErrorCodes.USER_NOT_FOUND, 'User not found', { id })
-  }
-}
-
-/**
- * Thrown when a route or query parameter is not a valid user identifier.
- *
- * @remarks
- * Used at validation boundaries before authorization or persistence access.
- * The raw, unparsed value is preserved in metadata to aid debugging.
- * @see {@link userInvalidId} for the factory helper
- * @example
- * ```typescript
- * const parsed = getUserProfileSchema.safeParse(request)
- * if (!parsed.success) {
- *   throw userInvalidId(request.params.userId)
- * }
- * ```
- */
-export class UserInvalidIdError extends ValidationError {
-  /**
-   * Creates a validation error for an invalid user identifier.
-   *
-   * @param rawId - Unparsed identifier from the request
-   * @returns A configured {@link UserInvalidIdError} instance
-   * @remarks
-   * Accepts `unknown` because invalid IDs may arrive as numbers, empty
-   * strings, or other non-string shapes from route parameters.
-   * @see {@link ErrorCodes.USER_INVALID_ID}
-   * @example
-   * ```typescript
-   * throw new UserInvalidIdError(undefined)
-   * ```
-   */
-  constructor(rawId: unknown) {
-    super(ErrorCodes.USER_INVALID_ID, 'Invalid user id', { rawId })
-  }
-}
-
-/**
- * Thrown when the caller lacks permission to access a user resource.
- *
- * @remarks
- * Raised after policy evaluation denies access—for example when a user
- * attempts to view private preferences or history belonging to another
- * account. Public profile reads currently pass policy checks.
- * @see {@link userUnauthorized} for the factory helper
- * @see {@link userPolicies} for authorization rules
- * @example
- * ```typescript
- * if (!userPolicies.canViewUserPreferences({ userId, targetId })) {
- *   throw userUnauthorized(targetId)
- * }
- * ```
- */
-export class UserUnauthorizedError extends AuthError {
-  /**
-   * Creates an authorization error for a denied access attempt.
-   *
-   * @param userId - User identifier that was denied access
-   * @returns A configured {@link UserUnauthorizedError} instance
-   * @remarks
-   * Stores the denied resource owner ID in metadata under
-   * {@link ErrorCodes.USER_UNAUTHORIZED}.
-   * @see {@link ErrorCodes.USER_UNAUTHORIZED}
-   * @example
-   * ```typescript
-   * throw new UserUnauthorizedError('other-user-id')
-   * ```
-   */
-  constructor(userId: string) {
-    super(ErrorCodes.USER_UNAUTHORIZED, 'Unauthorized user', { userId })
-  }
-}
+export * from '@domains/user/errors/user-error-classes'
 
 /**
  * Creates a {@link UserNotFoundError} for the given user identifier.

--- a/src/domains/user/policies/index.ts
+++ b/src/domains/user/policies/index.ts
@@ -11,4 +11,6 @@
  * import { userPolicies } from '@domains/user/policies'
  * ```
  */
+export * from './user-profile-policy'
+export * from './user-content-policy'
 export * from './user-policy'

--- a/src/domains/user/policies/user-content-policy.ts
+++ b/src/domains/user/policies/user-content-policy.ts
@@ -1,0 +1,84 @@
+/**
+ * Authorization policies for private user content (preferences and watch history).
+ *
+ * @module domains/user/policies/user-content-policy
+ * @remarks
+ * Pure, synchronous predicates: preferences and watch history are owner-only for both read and
+ * write. Composed into {@link userPolicies}.
+ *
+ * @see {@link PolicyParameters}
+ */
+import type { PolicyParameters } from '@domains/user/types/user-policies-types'
+
+/**
+ * Preference and watch-history view/edit policy checks (owner-only).
+ *
+ * @remarks Each `can*` method is a pure predicate; denied access should surface as
+ * {@link UserUnauthorizedError} from the calling service or route handler.
+ */
+export const userContentPolicies = {
+  /**
+   * Whether the caller may view user preferences.
+   *
+   * @param params - Actor and target identifiers
+   * @returns `true` when `userId` equals `targetId`; otherwise `false`
+   * @remarks
+   * **Rule:** Preferences are private. Only the owner may view
+   * {@link UserPreferences} fields: `fanaticLevel`, `frequency`,
+   * `preferredFormat`, `favoriteGenres`, `favoriteStudios`, and
+   * `favoriteAnimes`. Other users must not read preference data even if
+   * profile viewing is public.
+   * @see {@link canEditUserPreferences} for mutation rules (same ownership rule)
+   * @see {@link preferencesSchema} for the validated preference shape
+   */
+  canViewUserPreferences: ({ userId, targetId }: PolicyParameters) => {
+    return userId === targetId
+  },
+
+  /**
+   * Whether the caller may edit user preferences.
+   *
+   * @param params - Actor and target identifiers
+   * @returns `true` when `userId` equals `targetId`; otherwise `false`
+   * @remarks
+   * **Rule:** Only the owner may create or update preference fields.
+   * Attempts to modify another user's `fanaticLevel`, `frequency`,
+   * `preferredFormat`, or favorite lists must be rejected before persistence.
+   * @see {@link canViewUserPreferences} for read rules (same ownership rule)
+   * @see {@link UserPreferences}
+   */
+  canEditUserPreferences: ({ userId, targetId }: PolicyParameters) => {
+    return userId === targetId
+  },
+
+  /**
+   * Whether the caller may view watch history.
+   *
+   * @param params - Actor and target identifiers
+   * @returns `true` when `userId` equals `targetId`; otherwise `false`
+   * @remarks
+   * **Rule:** Watch history is private. Only the owner may view
+   * {@link UserHistory.watchedAnimes}. Other users cannot enumerate which
+   * anime titles another account has watched.
+   * @see {@link canEditUserHistory} for mutation rules (same ownership rule)
+   * @see {@link historySchema} for the validated history shape
+   */
+  canViewUserHistory: ({ userId, targetId }: PolicyParameters) => {
+    return userId === targetId
+  },
+
+  /**
+   * Whether the caller may edit watch history.
+   *
+   * @param params - Actor and target identifiers
+   * @returns `true` when `userId` equals `targetId`; otherwise `false`
+   * @remarks
+   * **Rule:** Only the owner may add, remove, or reorder entries in
+   * `watchedAnimes`. Cross-user history mutation is always denied.
+   * @see {@link canViewUserHistory} for read rules (same ownership rule)
+   * @see {@link UserHistory}
+   */
+  canEditUserHistory: ({ userId, targetId }: PolicyParameters) => {
+    return userId === targetId
+  },
+}

--- a/src/domains/user/policies/user-policy.ts
+++ b/src/domains/user/policies/user-policy.ts
@@ -7,6 +7,9 @@
  * (`userId`) may access a resource owned by `targetId`. Policies are invoked
  * by services before reads or writes; they never perform I/O.
  *
+ * Profile policies live in {@link user-profile-policy}; preference/history policies in
+ * {@link user-content-policy}. {@link userPolicies} composes both.
+ *
  * **Permission model summary**
  *
  * | Resource     | View                         | Edit              |
@@ -27,7 +30,8 @@
  * })
  * ```
  */
-import type { PolicyParameters } from '@domains/user/types/user-policies-types'
+import { userProfilePolicies } from '@domains/user/policies/user-profile-policy'
+import { userContentPolicies } from '@domains/user/policies/user-content-policy'
 
 /**
  * Policy checks for profile, preferences, and watch-history access.
@@ -38,142 +42,6 @@ import type { PolicyParameters } from '@domains/user/types/user-policies-types'
  * @see {@link PolicyParameters}
  */
 export const userPolicies = {
-  /**
-   * Whether the caller may view a user profile.
-   *
-   * @param _ - Actor and target identifiers (currently unused)
-   * @returns Always `true`; profiles are publicly readable
-   * @throws Does not throw; returns a boolean authorization result
-   * @remarks
-   * **Rule:** Any authenticated or anonymous caller may view any user
-   * profile. No ownership check is performed. This applies to the public
-   * profile fields exposed by {@link mapUserProfile} (identity, avatar,
-   * preferences, and history as returned by the API).
-   *
-   * If profiles become partially private in the future, this method is the
-   * single place to tighten view rules (for example, hide preferences for
-   * non-owners while keeping basic identity public).
-   * @see {@link canEditUserProfile} for profile mutation rules
-   * @see {@link userService.getUserProfile} which invokes this check before loading data
-   * @example
-   * ```typescript
-   * // Any user can view any profile
-   * userPolicies.canViewUserProfile({ userId: 'alice', targetId: 'bob' }) // true
-   * userPolicies.canViewUserProfile({ userId: 'bob', targetId: 'bob' }) // true
-   * ```
-   */
-  canViewUserProfile: (_: PolicyParameters) => {
-    return true
-  },
-
-  /**
-   * Whether the caller may edit a user profile.
-   *
-   * @param params - Actor and target identifiers
-   * @returns `true` when `userId` equals `targetId`; otherwise `false`
-   * @throws Does not throw; returns a boolean authorization result
-   * @remarks
-   * **Rule:** Only the profile owner may edit identity fields (`name`,
-   * `lastName`, `avatar`, `birthday`, `gender`). Cross-user edits are denied
-   * even for authenticated sessions.
-   * @see {@link canViewUserProfile} for read access (public)
-   * @see {@link UserProfile} for editable profile fields
-   * @example
-   * ```typescript
-   * userPolicies.canEditUserProfile({ userId: 'alice', targetId: 'bob' }) // false
-   * userPolicies.canEditUserProfile({ userId: 'alice', targetId: 'alice' }) // true
-   * ```
-   */
-  canEditUserProfile: ({ userId, targetId }: PolicyParameters) => {
-    return userId === targetId
-  },
-
-  /**
-   * Whether the caller may view user preferences.
-   *
-   * @param params - Actor and target identifiers
-   * @returns `true` when `userId` equals `targetId`; otherwise `false`
-   * @throws Does not throw; returns a boolean authorization result
-   * @remarks
-   * **Rule:** Preferences are private. Only the owner may view
-   * {@link UserPreferences} fields: `fanaticLevel`, `frequency`,
-   * `preferredFormat`, `favoriteGenres`, `favoriteStudios`, and
-   * `favoriteAnimes`. Other users must not read preference data even if
-   * profile viewing is public.
-   * @see {@link canEditUserPreferences} for mutation rules (same ownership rule)
-   * @see {@link preferencesSchema} for the validated preference shape
-   * @example
-   * ```typescript
-   * userPolicies.canViewUserPreferences({ userId: 'alice', targetId: 'bob' }) // false
-   * userPolicies.canViewUserPreferences({ userId: 'alice', targetId: 'alice' }) // true
-   * ```
-   */
-  canViewUserPreferences: ({ userId, targetId }: PolicyParameters) => {
-    return userId === targetId
-  },
-
-  /**
-   * Whether the caller may edit user preferences.
-   *
-   * @param params - Actor and target identifiers
-   * @returns `true` when `userId` equals `targetId`; otherwise `false`
-   * @throws Does not throw; returns a boolean authorization result
-   * @remarks
-   * **Rule:** Only the owner may create or update preference fields.
-   * Attempts to modify another user's `fanaticLevel`, `frequency`,
-   * `preferredFormat`, or favorite lists must be rejected before persistence.
-   * @see {@link canViewUserPreferences} for read rules (same ownership rule)
-   * @see {@link UserPreferences}
-   * @example
-   * ```typescript
-   * userPolicies.canEditUserPreferences({ userId: 'alice', targetId: 'bob' }) // false
-   * userPolicies.canEditUserPreferences({ userId: 'alice', targetId: 'alice' }) // true
-   * ```
-   */
-  canEditUserPreferences: ({ userId, targetId }: PolicyParameters) => {
-    return userId === targetId
-  },
-
-  /**
-   * Whether the caller may view watch history.
-   *
-   * @param params - Actor and target identifiers
-   * @returns `true` when `userId` equals `targetId`; otherwise `false`
-   * @throws Does not throw; returns a boolean authorization result
-   * @remarks
-   * **Rule:** Watch history is private. Only the owner may view
-   * {@link UserHistory.watchedAnimes}. Other users cannot enumerate which
-   * anime titles another account has watched.
-   * @see {@link canEditUserHistory} for mutation rules (same ownership rule)
-   * @see {@link historySchema} for the validated history shape
-   * @example
-   * ```typescript
-   * userPolicies.canViewUserHistory({ userId: 'alice', targetId: 'bob' }) // false
-   * userPolicies.canViewUserHistory({ userId: 'alice', targetId: 'alice' }) // true
-   * ```
-   */
-  canViewUserHistory: ({ userId, targetId }: PolicyParameters) => {
-    return userId === targetId
-  },
-
-  /**
-   * Whether the caller may edit watch history.
-   *
-   * @param params - Actor and target identifiers
-   * @returns `true` when `userId` equals `targetId`; otherwise `false`
-   * @throws Does not throw; returns a boolean authorization result
-   * @remarks
-   * **Rule:** Only the owner may add, remove, or reorder entries in
-   * `watchedAnimes`. Cross-user history mutation is always denied.
-   * @see {@link canViewUserHistory} for read rules (same ownership rule)
-   * @see {@link UserHistory}
-   * @example
-   * ```typescript
-   * userPolicies.canEditUserHistory({ userId: 'alice', targetId: 'bob' }) // false
-   * userPolicies.canEditUserHistory({ userId: 'alice', targetId: 'alice' }) // true
-   * ```
-   */
-  canEditUserHistory: ({ userId, targetId }: PolicyParameters) => {
-    return userId === targetId
-  },
+  ...userProfilePolicies,
+  ...userContentPolicies,
 }

--- a/src/domains/user/policies/user-profile-policy.ts
+++ b/src/domains/user/policies/user-profile-policy.ts
@@ -1,0 +1,69 @@
+/**
+ * Authorization policies for public user profile access.
+ *
+ * @module domains/user/policies/user-profile-policy
+ * @remarks
+ * Pure, synchronous predicates: profiles are publicly viewable but editable by their owner only.
+ * Composed into {@link userPolicies}.
+ *
+ * @see {@link PolicyParameters}
+ */
+import type { PolicyParameters } from '@domains/user/types/user-policies-types'
+
+/**
+ * Profile view/edit policy checks.
+ *
+ * @remarks Each `can*` method is a pure predicate; denied access should surface as
+ * {@link UserUnauthorizedError} from the calling service or route handler.
+ */
+export const userProfilePolicies = {
+  /**
+   * Whether the caller may view a user profile.
+   *
+   * @param _ - Actor and target identifiers (currently unused)
+   * @returns Always `true`; profiles are publicly readable
+   * @throws Does not throw; returns a boolean authorization result
+   * @remarks
+   * **Rule:** Any authenticated or anonymous caller may view any user
+   * profile. No ownership check is performed. This applies to the public
+   * profile fields exposed by {@link mapUserProfile} (identity, avatar,
+   * preferences, and history as returned by the API).
+   *
+   * If profiles become partially private in the future, this method is the
+   * single place to tighten view rules (for example, hide preferences for
+   * non-owners while keeping basic identity public).
+   * @see {@link canEditUserProfile} for profile mutation rules
+   * @see {@link userService.getUserProfile} which invokes this check before loading data
+   * @example
+   * ```typescript
+   * // Any user can view any profile
+   * userPolicies.canViewUserProfile({ userId: 'alice', targetId: 'bob' }) // true
+   * userPolicies.canViewUserProfile({ userId: 'bob', targetId: 'bob' }) // true
+   * ```
+   */
+  canViewUserProfile: (_: PolicyParameters) => {
+    return true
+  },
+
+  /**
+   * Whether the caller may edit a user profile.
+   *
+   * @param params - Actor and target identifiers
+   * @returns `true` when `userId` equals `targetId`; otherwise `false`
+   * @throws Does not throw; returns a boolean authorization result
+   * @remarks
+   * **Rule:** Only the profile owner may edit identity fields (`name`,
+   * `lastName`, `avatar`, `birthday`, `gender`). Cross-user edits are denied
+   * even for authenticated sessions.
+   * @see {@link canViewUserProfile} for read access (public)
+   * @see {@link UserProfile} for editable profile fields
+   * @example
+   * ```typescript
+   * userPolicies.canEditUserProfile({ userId: 'alice', targetId: 'bob' }) // false
+   * userPolicies.canEditUserProfile({ userId: 'alice', targetId: 'alice' }) // true
+   * ```
+   */
+  canEditUserProfile: ({ userId, targetId }: PolicyParameters) => {
+    return userId === targetId
+  },
+}

--- a/src/domains/user/schemas/index.ts
+++ b/src/domains/user/schemas/index.ts
@@ -11,4 +11,5 @@
  * import { userProfileSchema, getUserProfileSchema } from '@domains/user/schemas'
  * ```
  */
+export * from './user-preferences-schema'
 export * from './user-schema'

--- a/src/domains/user/schemas/user-preferences-schema.ts
+++ b/src/domains/user/schemas/user-preferences-schema.ts
@@ -1,0 +1,108 @@
+/**
+ * Zod schemas for nested user preference and history objects.
+ *
+ * @module domains/user/schemas/user-preferences-schema
+ * @remarks
+ * Sub-schemas composed into {@link userProfileSchema}. Types in
+ * {@link module:domains/user/types/user-types} are inferred from these to keep validation and
+ * TypeScript in sync.
+ *
+ * @see {@link userProfileSchema}
+ */
+import { z } from 'zod'
+
+/**
+ * Optional fan engagement level for user preferences.
+ *
+ * @returns A Zod enum schema accepting `'low'`, `'medium'`, or `'high'`
+ * @throws {ZodError} When validation runs and the value is outside the enum
+ * @remarks
+ * Describes how invested the user is in anime culture. Stored in
+ * `profile.fanatic_level` and mapped to {@link UserFanaticLevel}.
+ * @see {@link preferencesSchema}
+ * @example
+ * ```typescript
+ * fanaticLevelSchema.parse('high') // 'high'
+ * fanaticLevelSchema.parse(undefined) // undefined
+ * ```
+ */
+export const fanaticLevelSchema = z.enum(['low', 'medium', 'high']).optional()
+
+/**
+ * Optional viewing frequency for user preferences.
+ *
+ * @returns A Zod enum schema accepting `'daily'`, `'weekly'`, or `'monthly'`
+ * @throws {ZodError} When validation runs and the value is outside the enum
+ * @remarks
+ * How often the user typically watches anime. Stored in `profile.frequency`
+ * and mapped to {@link UserFrequency}.
+ * @see {@link preferencesSchema}
+ * @example
+ * ```typescript
+ * frequencySchema.parse('weekly') // 'weekly'
+ * ```
+ */
+export const frequencySchema = z.enum(['daily', 'weekly', 'monthly']).optional()
+
+/**
+ * Validates nested user preference fields.
+ *
+ * @returns A Zod object schema for {@link UserPreferences}
+ * @throws {ZodError} When validation runs and any field fails its constraint
+ * @remarks
+ * **Preference fields:**
+ *
+ * | Field | Type | Required | Description |
+ * | ----- | ---- | -------- | ----------- |
+ * | `fanaticLevel` | `'low' \| 'medium' \| 'high'` | no | Engagement level |
+ * | `frequency` | `'daily' \| 'weekly' \| 'monthly'` | no | Viewing cadence |
+ * | `preferredFormat` | `string` | no | Preferred media format (e.g. TV, movie) |
+ * | `favoriteGenres` | `number[]` | no | Taxonomy IDs for favorite genres |
+ * | `favoriteStudios` | `number[]` | no | Taxonomy IDs for favorite studios |
+ * | `favoriteAnimes` | `number[]` | no | Media IDs for favorite anime titles |
+ *
+ * Access is restricted by {@link userPolicies.canViewUserPreferences} and
+ * {@link userPolicies.canEditUserPreferences} (owner only).
+ * @see {@link fanaticLevelSchema}
+ * @see {@link frequencySchema}
+ * @example
+ * ```typescript
+ * preferencesSchema.parse({
+ *   fanaticLevel: 'medium',
+ *   frequency: 'weekly',
+ *   favoriteAnimes: [1, 42, 100],
+ * })
+ * ```
+ */
+export const preferencesSchema = z.object({
+  fanaticLevel: fanaticLevelSchema,
+  frequency: frequencySchema,
+  preferredFormat: z.string().optional(),
+  favoriteGenres: z.array(z.number()).optional(),
+  favoriteStudios: z.array(z.number()).optional(),
+  favoriteAnimes: z.array(z.number()).optional(),
+})
+
+/**
+ * Validates watch history fields on a user profile.
+ *
+ * @returns A Zod object schema for {@link UserHistory}
+ * @throws {ZodError} When validation runs and `watchedAnimes` is not a number array
+ * @remarks
+ * **History fields:**
+ *
+ * | Field | Type | Required | Description |
+ * | ----- | ---- | -------- | ----------- |
+ * | `watchedAnimes` | `number[]` | no | Media IDs the user has watched |
+ *
+ * Access is restricted by {@link userPolicies.canViewUserHistory} and
+ * {@link userPolicies.canEditUserHistory} (owner only).
+ * @see {@link userProfileSchema}
+ * @example
+ * ```typescript
+ * historySchema.parse({ watchedAnimes: [10, 20, 30] })
+ * ```
+ */
+export const historySchema = z.object({
+  watchedAnimes: z.array(z.number()).optional(),
+})

--- a/src/domains/user/schemas/user-schema.ts
+++ b/src/domains/user/schemas/user-schema.ts
@@ -25,102 +25,14 @@
  */
 import { z } from 'zod'
 import { createApiResponseSchema } from '@shared/schemas/api-schema'
+import {
+  historySchema,
+  preferencesSchema,
+} from '@domains/user/schemas/user-preferences-schema'
 
-/**
- * Optional fan engagement level for user preferences.
- *
- * @returns A Zod enum schema accepting `'low'`, `'medium'`, or `'high'`
- * @throws {ZodError} When validation runs and the value is outside the enum
- * @remarks
- * Describes how invested the user is in anime culture. Stored in
- * `profile.fanatic_level` and mapped to {@link UserFanaticLevel}.
- * @see {@link preferencesSchema}
- * @example
- * ```typescript
- * fanaticLevelSchema.parse('high') // 'high'
- * fanaticLevelSchema.parse(undefined) // undefined
- * ```
- */
-export const fanaticLevelSchema = z.enum(['low', 'medium', 'high']).optional()
-
-/**
- * Optional viewing frequency for user preferences.
- *
- * @returns A Zod enum schema accepting `'daily'`, `'weekly'`, or `'monthly'`
- * @throws {ZodError} When validation runs and the value is outside the enum
- * @remarks
- * How often the user typically watches anime. Stored in `profile.frequency`
- * and mapped to {@link UserFrequency}.
- * @see {@link preferencesSchema}
- * @example
- * ```typescript
- * frequencySchema.parse('weekly') // 'weekly'
- * ```
- */
-export const frequencySchema = z.enum(['daily', 'weekly', 'monthly']).optional()
-
-/**
- * Validates nested user preference fields.
- *
- * @returns A Zod object schema for {@link UserPreferences}
- * @throws {ZodError} When validation runs and any field fails its constraint
- * @remarks
- * **Preference fields:**
- *
- * | Field | Type | Required | Description |
- * | ----- | ---- | -------- | ----------- |
- * | `fanaticLevel` | `'low' \| 'medium' \| 'high'` | no | Engagement level |
- * | `frequency` | `'daily' \| 'weekly' \| 'monthly'` | no | Viewing cadence |
- * | `preferredFormat` | `string` | no | Preferred media format (e.g. TV, movie) |
- * | `favoriteGenres` | `number[]` | no | Taxonomy IDs for favorite genres |
- * | `favoriteStudios` | `number[]` | no | Taxonomy IDs for favorite studios |
- * | `favoriteAnimes` | `number[]` | no | Media IDs for favorite anime titles |
- *
- * Access is restricted by {@link userPolicies.canViewUserPreferences} and
- * {@link userPolicies.canEditUserPreferences} (owner only).
- * @see {@link fanaticLevelSchema}
- * @see {@link frequencySchema}
- * @example
- * ```typescript
- * preferencesSchema.parse({
- *   fanaticLevel: 'medium',
- *   frequency: 'weekly',
- *   favoriteAnimes: [1, 42, 100],
- * })
- * ```
- */
-export const preferencesSchema = z.object({
-  fanaticLevel: fanaticLevelSchema,
-  frequency: frequencySchema,
-  preferredFormat: z.string().optional(),
-  favoriteGenres: z.array(z.number()).optional(),
-  favoriteStudios: z.array(z.number()).optional(),
-  favoriteAnimes: z.array(z.number()).optional(),
-})
-
-/**
- * Validates watch history fields on a user profile.
- *
- * @returns A Zod object schema for {@link UserHistory}
- * @throws {ZodError} When validation runs and `watchedAnimes` is not a number array
- * @remarks
- * **History fields:**
- *
- * | Field | Type | Required | Description |
- * | ----- | ---- | -------- | ----------- |
- * | `watchedAnimes` | `number[]` | no | Media IDs the user has watched |
- *
- * Access is restricted by {@link userPolicies.canViewUserHistory} and
- * {@link userPolicies.canEditUserHistory} (owner only).
- * @see {@link userProfileSchema}
- * @example
- * ```typescript
- * historySchema.parse({ watchedAnimes: [10, 20, 30] })
- * ```
- */
-export const historySchema = z.object({
-  watchedAnimes: z.array(z.number()).optional(),
-})
+// Re-exported so consumers importing from `@domains/user/schemas/user-schema`
+// keep access to the nested preference/history schemas.
+export * from '@domains/user/schemas/user-preferences-schema'
 
 /**
  * Validates the public user profile payload.


### PR DESCRIPTION
## Summary

- Splits user domain into separate error types, access policies, and Zod schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)