### PR TITLE
refactor(auth): Extract session schema and unify APP_BASE_URL

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -30,9 +30,8 @@ import { z } from 'zod'
  * @property TURSO_DATABASE_URL - LibSQL/Turso database URL (must be valid URL).
  * @property TURSO_AUTH_TOKEN - Non-empty auth token for Turso remote access.
  * @property SENTRY_DSN - Optional Sentry project DSN; monitoring no-ops when absent.
- * @property APP_BASE_URL - Optional public site URL override for SEO and links.
+ * @property APP_BASE_URL - Public origin used as Better Auth base URL and SEO canonical.
  * @property BETTER_AUTH_SECRET - Session signing secret; minimum 32 characters.
- * @property BETTER_AUTH_URL - Public origin Better Auth uses for callbacks.
  * @property UPSTASH_REDIS_REST_URL - Upstash Redis REST endpoint URL.
  * @property UPSTASH_REDIS_REST_TOKEN - Non-empty Upstash REST API token.
  * @property LOG_LEVEL - Optional Pino/log level; one of trace through fatal.

--- a/src/domains/auth/schemas/index.ts
+++ b/src/domains/auth/schemas/index.ts
@@ -24,3 +24,5 @@
 
 /** Zod schemas and inferred types for login and registration payloads. */
 export * from './login-schema'
+/** Zod schema for Better Auth session lookup responses. */
+export * from './session-schema'

--- a/src/domains/auth/schemas/login-schema.ts
+++ b/src/domains/auth/schemas/login-schema.ts
@@ -14,6 +14,10 @@
  */
 import { z } from 'zod'
 
+// Re-exported so consumers importing from `@domains/auth/schemas/login-schema`
+// keep access to the session response schema.
+export * from '@domains/auth/schemas/session-schema'
+
 /**
  * Validates email/password login request bodies.
  *
@@ -75,54 +79,6 @@ export const registerSchema = z.object({
     /** Display name; required, at least one character. */
     name: z.string().min(1),
   }),
-})
-
-/**
- * Validates session lookup responses from Better Auth `getSession`.
- *
- * @remarks
- * **Fields**:
- * - `user` — nullable object:
- *   - `id` — `string`, user identifier
- *   - `email` — `string`, user email
- *   - `name` — `string`, display name
- * - `session` — nullable object:
- *   - `id` — `string`, session identifier
- *   - `userId` — `string`, owning user id
- *   - `expiresAt` — `Date`, coerced from ISO string via `z.coerce.date()`
- *
- * Both `user` and `session` are `null` when the request is unauthenticated.
- *
- * @see {@link sessionService.getSession} — produces data matching this shape
- * @see {@link resolveAuthActor} — extracts `user` and `session` for Astro locals
- *
- * @example
- * ```typescript
- * const sessionData = await sessionService.getSession(request.headers)
- * const validated = sessionResponseSchema.parse(sessionData)
- * ```
- */
-export const sessionResponseSchema = z.object({
-  user: z
-    .object({
-      /** Better Auth user identifier. */
-      id: z.string(),
-      /** User email address. */
-      email: z.string(),
-      /** User display name. */
-      name: z.string(),
-    })
-    .nullable(),
-  session: z
-    .object({
-      /** Better Auth session identifier. */
-      id: z.string(),
-      /** ID of the user this session belongs to. */
-      userId: z.string(),
-      /** Session expiration timestamp (coerced to Date). */
-      expiresAt: z.coerce.date(),
-    })
-    .nullable(),
 })
 
 /**

--- a/src/domains/auth/schemas/session-schema.ts
+++ b/src/domains/auth/schemas/session-schema.ts
@@ -1,0 +1,60 @@
+/**
+ * Zod schema for Better Auth session lookup responses.
+ *
+ * @module domains/auth/schemas/session-schema
+ * @remarks
+ * Validates the shape returned by Better Auth `getSession`. Both `user` and `session` are
+ * `null` when the request is unauthenticated.
+ *
+ * @see {@link sessionService.getSession} — produces data matching this shape
+ * @see {@link resolveAuthActor} — extracts `user` and `session` for Astro locals
+ */
+import { z } from 'zod'
+
+/**
+ * Validates session lookup responses from Better Auth `getSession`.
+ *
+ * @remarks
+ * **Fields**:
+ * - `user` — nullable object:
+ *   - `id` — `string`, user identifier
+ *   - `email` — `string`, user email
+ *   - `name` — `string`, display name
+ * - `session` — nullable object:
+ *   - `id` — `string`, session identifier
+ *   - `userId` — `string`, owning user id
+ *   - `expiresAt` — `Date`, coerced from ISO string via `z.coerce.date()`
+ *
+ * Both `user` and `session` are `null` when the request is unauthenticated.
+ *
+ * @see {@link sessionService.getSession} — produces data matching this shape
+ * @see {@link resolveAuthActor} — extracts `user` and `session` for Astro locals
+ *
+ * @example
+ * ```typescript
+ * const sessionData = await sessionService.getSession(request.headers)
+ * const validated = sessionResponseSchema.parse(sessionData)
+ * ```
+ */
+export const sessionResponseSchema = z.object({
+  user: z
+    .object({
+      /** Better Auth user identifier. */
+      id: z.string(),
+      /** User email address. */
+      email: z.string(),
+      /** User display name. */
+      name: z.string(),
+    })
+    .nullable(),
+  session: z
+    .object({
+      /** Better Auth session identifier. */
+      id: z.string(),
+      /** ID of the user this session belongs to. */
+      userId: z.string(),
+      /** Session expiration timestamp (coerced to Date). */
+      expiresAt: z.coerce.date(),
+    })
+    .nullable(),
+})

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -14,7 +14,6 @@
  * @see {@link authClient} for the singleton instance
  */
 import { createAuthClient } from 'better-auth/client'
-import type { Auth } from './server'
 
 /**
  * Typed Better Auth client for browser session and credential operations.
@@ -34,7 +33,5 @@ import type { Auth } from './server'
  *
  * const { data: session } = await authClient.getSession()
  * ```
- *
- * @see {@link Auth} for the server type binding
  */
-export const authClient = createAuthClient<Auth>({})
+export const authClient = createAuthClient()

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -37,7 +37,7 @@ import {
  */
 export const auth = betterAuth({
   secret: env.BETTER_AUTH_SECRET,
-  baseURL: env.BETTER_AUTH_URL,
+  baseURL: env.APP_BASE_URL,
   emailAndPassword: {
     enabled: true,
   },

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -16,10 +16,10 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping via {@link withErrorHandling}
  */
 
-import type { APIRoute } from 'astro'
+import type { APIRoute, APIContext } from 'astro'
 import { withZodValidation } from '@http/with-validation'
 import { withErrorHandling } from '@http/with-error-handling'
-import { loginSchema } from '@domains/auth/schemas'
+import { loginSchema, type LoginInput } from '@domains/auth/schemas'
 import { credentialsService } from '@domains/auth/services'
 
 /**
@@ -78,7 +78,13 @@ import { credentialsService } from '@domains/auth/services'
  * ```
  */
 export const POST: APIRoute = withZodValidation(loginSchema)(
-  withErrorHandling(async ({ request, validated }) => {
+  withErrorHandling(
+    async ({
+      request,
+      validated,
+    }: APIContext & {
+      validated: { body: LoginInput }
+    }) => {
     const result = await credentialsService.login(
       validated.body,
       request.headers

--- a/src/pages/api/auth/register.ts
+++ b/src/pages/api/auth/register.ts
@@ -16,10 +16,10 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping via {@link withErrorHandling}
  */
 
-import type { APIRoute } from 'astro'
+import type { APIRoute, APIContext } from 'astro'
 import { withZodValidation } from '@http/with-validation'
 import { withErrorHandling } from '@http/with-error-handling'
-import { registerSchema } from '@domains/auth/schemas'
+import { registerSchema, type RegisterInput } from '@domains/auth/schemas'
 import { credentialsService } from '@domains/auth/services'
 
 /**
@@ -81,7 +81,13 @@ import { credentialsService } from '@domains/auth/services'
  * ```
  */
 export const POST: APIRoute = withZodValidation(registerSchema)(
-  withErrorHandling(async ({ request, validated }) => {
+  withErrorHandling(
+    async ({
+      request,
+      validated,
+    }: APIContext & {
+      validated: { body: RegisterInput }
+    }) => {
     const result = await credentialsService.register(
       validated.body,
       request.headers


### PR DESCRIPTION
## Summary

- Extracts session schema into its own module
- Unifies `APP_BASE_URL` across the auth domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)