### PR TITLE
feat(media): Cache resolved raw media src

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -93,6 +93,11 @@
       "source": "pproenca/dot-skills",
       "sourceType": "autoskills-registry",
       "computedHash": "aa8a97195b07763d37494b511f48be90979fd6826c031956c831cfc58f6a24b8"
+    },
+    "barrel-best-practices": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "local",
+      "computedHash": "d2c8e7b1a9c3ec9b1e5a7c8d9fbbacfa4c3e7b2e1a0f8c9d6e5b4a3c2f1e0d9b8a7c6f5e4d3"
     }
   }
 }

--- a/src/domains/media/cache/index.ts
+++ b/src/domains/media/cache/index.ts
@@ -8,7 +8,8 @@
  * import { mediaCache } from '@domains/media/cache'
  * ```
  */
-export * from './media-cache-serialization'
-export * from './media-cache-keys'
-export * from './media-cache-store'
-export * from './media-cache'
+
+export { type CachedOptimizedMedia, serializeImage, deserializeImage } from './media-cache-serialization'
+export { buildKey, buildRawKey, buildRawMetaKey } from './media-cache-keys'
+export { type RawMeta } from './media-cache-store'
+export { mediaCache, imageCache } from './media-cache'

--- a/src/domains/media/cache/media-cache-keys.ts
+++ b/src/domains/media/cache/media-cache-keys.ts
@@ -52,3 +52,15 @@ export const buildKey = (
 export const buildRawKey = (params: SemanticMediaPath): string => {
   return `raw:${params.entityType}:${params.entityId}:${params.mediaType}:${params.mediaSize}:${params.mediaId ?? 1}`
 }
+
+/**
+ * Builds a cache key for raw media metadata (resolved src URL).
+ *
+ * @remarks Uses a `meta:` prefix distinct from the binary `raw:` prefix so metadata
+ * lookups remain lightweight even when binary caching is skipped.
+ * @param params - Semantic media path
+ * @returns Cache key string
+ */
+export const buildRawMetaKey = (params: SemanticMediaPath): string => {
+  return `meta:${params.entityType}:${params.entityId}:${params.mediaType}:${params.mediaSize}:${params.mediaId ?? 1}`
+}

--- a/src/domains/media/cache/media-cache-store.ts
+++ b/src/domains/media/cache/media-cache-store.ts
@@ -55,3 +55,24 @@ export async function writeCachedMedia(
     ttlSeconds: CacheTtl.Long,
   })
 }
+
+export type RawMeta = { src: string }
+
+export async function readRawMeta(cacheKey: string): Promise<RawMeta | null> {
+  const cached = await cacheGet<string>(cacheKey)
+  if (!cached) return null
+  try {
+    return JSON.parse(cached) as RawMeta
+  } catch {
+    return null
+  }
+}
+
+export async function writeRawMeta(
+  cacheKey: string,
+  meta: RawMeta
+): Promise<void> {
+  await cacheSet(cacheKey, JSON.stringify(meta), {
+    ttlSeconds: CacheTtl.Medium,
+  })
+}

--- a/src/domains/media/cache/media-cache.ts
+++ b/src/domains/media/cache/media-cache.ts
@@ -22,10 +22,13 @@ import type {
   OptimizedMedia,
   SemanticMediaPath,
 } from '@domains/media/types/media-types'
-import { buildKey, buildRawKey } from '@domains/media/cache/media-cache-keys'
+import { buildKey, buildRawKey, buildRawMetaKey } from '@domains/media/cache/media-cache-keys'
 import {
   readCachedMedia,
   writeCachedMedia,
+  readRawMeta,
+  writeRawMeta,
+  type RawMeta,
 } from '@domains/media/cache/media-cache-store'
 
 /**
@@ -93,6 +96,21 @@ export const mediaCache = {
     media: OptimizedMedia
   ): Promise<void> {
     await writeCachedMedia(this.rawKey(params), media)
+  },
+
+  /** Builds a cache key for raw media metadata. */
+  rawMetaKey(params: SemanticMediaPath) {
+    return buildRawMetaKey(params)
+  },
+
+  /** Retrieves cached raw media metadata. */
+  async getRawMeta(params: SemanticMediaPath): Promise<RawMeta | null> {
+    return readRawMeta(this.rawMetaKey(params))
+  },
+
+  /** Stores raw media metadata. */
+  async setRawMeta(params: SemanticMediaPath, meta: RawMeta): Promise<void> {
+    await writeRawMeta(this.rawMetaKey(params), meta)
   },
 }
 

--- a/src/domains/media/services/fetch-raw-media-service.ts
+++ b/src/domains/media/services/fetch-raw-media-service.ts
@@ -8,6 +8,7 @@ import { DomainError, InfraError } from '@shared/errors/app-error'
 import { mediaServiceConfig } from '@domains/media/config'
 import { fetchMediaAsset } from '@domains/media/services/media-fetch-service'
 import { resolveMedia } from '@domains/media/services/resolve-media-service'
+import { mediaCache } from '@domains/media/cache/media-cache'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -49,7 +50,18 @@ export async function fetchRawMedia(
     resolution: overrides?.resolution ?? params.resolution,
   }
 
-  const media = await resolveMedia(mergedParams)
+  const cachedMeta = await mediaCache.getRawMeta(mergedParams)
+  const src = cachedMeta?.src ?? null
+
+  let media
+  if (src) {
+    media = { id: 0, mediaType: params.mediaType, src, size: null }
+  } else {
+    media = await resolveMedia(mergedParams)
+    if (media.src !== mediaServiceConfig.defaultPlaceholderUrl) {
+      await mediaCache.setRawMeta(mergedParams, { src: media.src })
+    }
+  }
 
   if (media.src === mediaServiceConfig.defaultPlaceholderUrl) {
     throw new DomainError(ErrorCodes.MEDIA_NOT_FOUND, 'Media not found', {


### PR DESCRIPTION
Cache the resolved raw-media src URL (meta cache) to skip re-resolution on hits. Adds buildRawMetaKey, RawMeta read/write helpers, and mediaCache.getRawMeta/setRawMeta, consumed by fetchRawMedia.