### PR TITLE
Add Dockerfile and CI/CD workflow for production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: ["master"]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/anidev-v2:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/anidev-v2:${{ github.sha }}
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,14 @@ ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000
 
-COPY --from=build /app/dist ./dist
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/package.json ./package.json
+RUN addgroup --system --gid 1001 bunjs \
+  && adduser --system --uid 1001 astro
+
+COPY --from=build --chown=astro:bunjs /app/dist ./dist
+COPY --from=build --chown=astro:bunjs /app/node_modules ./node_modules
+COPY --from=build --chown=astro:bunjs /app/package.json ./package.json
+
+USER astro
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM oven/bun:1.2 AS base
+WORKDIR /app
+
+FROM base AS install
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+
+FROM base AS build
+COPY --from=install /app/node_modules ./node_modules
+COPY . .
+ENV NODE_ENV=production
+RUN bun run build
+
+FROM base AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3000
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+
+EXPOSE 3000
+
+CMD ["bun", "run", "dist/server/entry.mjs"]


### PR DESCRIPTION
Agrega Dockerfile multi-stage con Bun y workflow de GitHub Actions para build/push a Docker Hub, siguiendo la guia de produccion de Dokploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added containerized production builds for the application.
  * The application is available through a Docker image and runs on port 3000.
  * Automated builds publish updated images when changes are pushed to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->