### PR TITLE
fix(ci): Pass ASTRO_ADAPTER=bun build-arg to Docker workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          build-args: |
+            ASTRO_ADAPTER=bun
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/anidev-v2:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/anidev-v2:${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          build-args: |
+            ASTRO_ADAPTER=bun
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/anidev-v2:${{ github.ref_name }}
             ${{ !contains(github.ref_name, '-') && format('{0}/anidev-v2:latest', secrets.DOCKERHUB_USERNAME) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.2](https://github.com/Sebas200702/anidev-v2/compare/v0.1.1...v0.1.2) (2026-08-07)
+
+
+### Bug Fixes
+
+* **ci:** Pass ASTRO_ADAPTER=bun build-arg to Docker workflows ([6619c8b](https://github.com/Sebas200702/anidev-v2/commit/6619c8b7bde21b8c780b7860d7664c16faf04684))
+
 ### [0.1.1](https://github.com/Sebas200702/anidev-v2/compare/v0.1.0...v0.1.1) (2026-08-07)
 
 

--- a/openspec/changes/fix-docker-astro-bun-build-arg/.openspec.yaml
+++ b/openspec/changes/fix-docker-astro-bun-build-arg/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-07
+skip_specs: true

--- a/openspec/changes/fix-docker-astro-bun-build-arg/design.md
+++ b/openspec/changes/fix-docker-astro-bun-build-arg/design.md
@@ -1,0 +1,30 @@
+## Context
+
+See proposal.md - Why. The Dockerfile already consumes `ASTRO_ADAPTER` via `ARG ASTRO_ADAPTER` / `ENV ASTRO_ADAPTER=$ASTRO_ADAPTER` (Dockerfile:11-12), and `astro.config.mjs:19` switches to the `@nurodev/astro-bun` adapter when `ASTRO_ADAPTER === 'bun'`, producing `dist/server/entry.mjs`. The gap is purely that the two Docker-publishing workflows never pass the build-arg, so the Vercel adapter default is used.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make both Docker publishing workflows build the image with `ASTRO_ADAPTER=bun`.
+- Produce a runtime image whose `CMD ["bun", "run", "dist/server/entry.mjs"]` succeeds.
+
+**Non-Goals:**
+
+- No Dockerfile changes — the ARG/ENV plumbing already exists.
+- No application code or runtime behavior changes.
+- No changes to the Vercel adapter path used by CI serverless builds.
+
+## Decisions
+
+**Pass the build-arg in both `release.yml` and `deploy.yml`.**
+The same bug exists in two files; fixing only `release.yml` would leave `deploy.yml` publishing the broken image on every `master` push.
+
+Alternative considered: hardcoding `ASTRO_ADAPTER=bun` in `astro.config.mjs` — rejected, because CI's Vercel adapter build (and the `bun run build` used by `check`/`build` gates) depends on the default, and the config comment explicitly documents the env-switch contract.
+
+**Use the `build-args: |` YAML block syntax**, matching how `tags:` is expressed in the same step for consistency. No secrets involved — `ASTRO_ADAPTER` is a build-time constant.
+
+## Risks / Trade-offs
+
+- A future contributor could re-introduce the gap if a new Docker-building workflow is added → the change keeps the two workflows consistent and the Dockerfile comment already documents the `ASTRO_ADAPTER` contract; a build test could be added later but is out of scope here.
+- `bun run build` runs with `NODE_ENV=production` and placeholder env in the build stage; this already works for the Vercel path, and the Bun adapter build is exercised locally by the same script, so no new build-stage risk is introduced.

--- a/openspec/changes/fix-docker-astro-bun-build-arg/proposal.md
+++ b/openspec/changes/fix-docker-astro-bun-build-arg/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The Docker images published to Docker Hub (`anidev-v2:latest` and version/sha tags) are built without the `ASTRO_ADAPTER=bun` build-arg, so Astro compiles with the default Vercel/serverless adapter and never emits `dist/server/entry.mjs`. The runtime image's `CMD ["bun", "run", "dist/server/entry.mjs"]` (Dockerfile:45) therefore fails at startup.
+
+## What Changes
+
+- Add `build-args: | ASTRO_ADAPTER=bun` to the "Build and push Docker image" step in `.github/workflows/release.yml`.
+- Add the same `build-args` block to the identical step in `.github/workflows/deploy.yml`, which shares the same bug.
+- The Dockerfile already declares `ARG ASTRO_ADAPTER` / `ENV ASTRO_ADAPTER=$ASTRO_ADAPTER` (lines 11-12), so no Dockerfile change is needed.
+- No application code, runtime behavior, or public spec changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. Pure CI/CD tooling fix — declared via `skip_specs: true` in `.openspec.yaml`.
+
+## Impact
+
+- `.github/workflows/release.yml` — Docker build step gains the `ASTRO_ADAPTER=bun` build-arg.
+- `.github/workflows/deploy.yml` — same change for parity.
+- Docker image builds now emit a standalone Bun server (`dist/server/entry.mjs`), which is what the runtime `CMD` expects.
+- Rebuilding requires a new release tag (`v*`) for `release.yml`, or a push to `master` for `deploy.yml`.

--- a/openspec/changes/fix-docker-astro-bun-build-arg/tasks.md
+++ b/openspec/changes/fix-docker-astro-bun-build-arg/tasks.md
@@ -1,0 +1,10 @@
+## 1. Pass the Bun adapter build-arg in the Docker publishing workflows
+
+- [x] 1.1 Add `build-args: |` with `ASTRO_ADAPTER=bun` to the "Build and push Docker image" step in `.github/workflows/release.yml`
+- [x] 1.2 Add the same `build-args: |` block with `ASTRO_ADAPTER=bun` to the matching step in `.github/workflows/deploy.yml`
+
+## 2. Verify and release
+
+- [x] 2.1 Confirm the Dockerfile needs no change (`ARG`/`ENV` already consume `ASTRO_ADAPTER`) and the workflow YAML is valid
+- [ ] 2.2 Run the Verification gate and open a PR to `master` on branch `ci/fix-docker-astro-bun-build-arg`
+- [ ] 2.3 Run `bun run release:patch` on the branch so the PR carries the version bump and `v0.1.2` tag, then merge and push the tag to trigger `release.yml` and rebuild the image

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anidev-v2",
   "type": "module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "engines": {
     "node": ">=22.12.0"
   },


### PR DESCRIPTION
## Why
The Docker images published to Docker Hub are built without the `ASTRO_ADAPTER=bun` build-arg, so Astro compiles with the default Vercel/serverless adapter and never emits `dist/server/entry.mjs`. The runtime image's `CMD ["bun", "run", "dist/server/entry.mjs"]` (Dockerfile:45) therefore fails at startup.

## What
- `release.yml`: added `build-args: | ASTRO_ADAPTER=bun` to the 'Build and push Docker image' step.
- `deploy.yml`: same fix — it shared the identical bug.
- No Dockerfile change needed: `ARG ASTRO_ADAPTER` / `ENV ASTRO_ADAPTER=$ASTRO_ADAPTER` (Dockerfile:11-12) already consume it.

## Verification
Gate passed locally: format ✓ check ✓ check:types ✓ test (41) ✓ build ✓

## Release
Bump 0.1.1 → 0.1.2 (patch, `fix(ci)`) rides on this branch with tag `v0.1.2` so the merge triggers a Docker image rebuild via `release.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker image builds so the application uses the Bun runtime configuration correctly in deployment and release workflows.
  * Ensured generated server output matches the configured runtime command.

* **Release**
  * Updated the package version to 0.1.2.
  * Added changelog details for the Docker build fix.

* **Documentation**
  * Added implementation notes and validation steps for the build configuration update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->