### PR TITLE
fix(db): Break circular import between auth-schema and auth-relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.3](https://github.com/Sebas200702/anidev-v2/compare/v0.1.2...v0.1.3) (2026-08-07)
+
+
+### Bug Fixes
+
+* **db:** Break circular import between auth-schema and auth-relations ([735e0fc](https://github.com/Sebas200702/anidev-v2/commit/735e0fc41671b821a3aaf9a8ee43862d782dbbbc))
+
 ### [0.1.2](https://github.com/Sebas200702/anidev-v2/compare/v0.1.1...v0.1.2) (2026-08-07)
 
 

--- a/openspec/changes/fix-auth-schema-circular-import/.openspec.yaml
+++ b/openspec/changes/fix-auth-schema-circular-import/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-07
+skip_specs: true

--- a/openspec/changes/fix-auth-schema-circular-import/design.md
+++ b/openspec/changes/fix-auth-schema-circular-import/design.md
@@ -1,0 +1,31 @@
+## Context
+
+See proposal.md - Why. Confirmed in the production chunk `dist/server/chunks/auth-schema_BJlawpky.mjs`: the bundler emitted `relations(user, ...)` calls (lines 4-19) before the `const user` declaration (line 21), producing a TDZ ReferenceError. The chunk loads lazily, so the server starts but crashes when a route touches auth schema.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminate the circular dependency so the bundler can order tables before relations.
+- Keep the public export surface (`user`, `session`, `account`, `verification`, `userRelations`, `sessionRelations`, `accountRelations`) identical.
+
+**Non-Goals:**
+
+- No schema/table/column changes.
+- No consumer-code changes outside the two schema modules (verified none import relations from `auth-schema`).
+- No changes to the unrelated Redis/Dragonfly `ENOTFOUND` DNS issue reported in the same logs (separate infra concern).
+
+## Decisions
+
+**Break the cycle by removing the re-export from `auth-schema.ts`.**
+The relations file imports tables from `auth-schema`; making `auth-schema` also export from the relations file creates a two-way edge. Removing that re-export leaves a single directed edge `auth-relations → auth-schema`, so chunking has a canonical order.
+
+Alternative considered: inverting the direction (relations file imports tables, tables file imports relations) — rejected, tables are the primitive layer and relations reference them; `auth-schema` must not depend on `auth-relations`.
+
+**Update the barrel `index.ts` to import relations from `./auth-relations`.**
+The barrel is the only consumer of the relations through `auth-schema`. Splitting the export keeps the barrel's public API unchanged while sourcing each symbol from its defining module — matching how the barrel already imports anime relations (`./anime-entity-relations`, `./anime-taxonomy-relations`).
+
+## Risks / Trade-offs
+
+- A future contributor re-introduces the re-export → the codebase's "isolate imports from individual schema files to avoid circular imports" convention (`index.ts` module doc) plus the chunk-level build check below serve as guardrails.
+- The TDZ error is platform/ordering-dependent (may not reproduce on every local build) → the verification step builds with `ASTRO_ADAPTER=bun` (same as the Docker runtime) and greps the produced chunk to confirm the relations calls now appear after the table declarations.

--- a/openspec/changes/fix-auth-schema-circular-import/proposal.md
+++ b/openspec/changes/fix-auth-schema-circular-import/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Production crashes at runtime with `ReferenceError: Cannot access 'user' before initialization`. The build output chunk `auth-schema_*.mjs` hoists the Drizzle `relations(user, ...)` calls before the `const user` table declarations. Root cause: a circular import between `auth-schema.ts` and `auth-relations.ts`.
+
+- `auth-relations.ts` imports `{ account, session, user }` from `@db/schemas/auth-schema`.
+- `auth-schema.ts` re-exports `{ userRelations, sessionRelations, accountRelations }` from `@db/schemas/auth-relations` at the bottom (line 145-149).
+
+The re-export makes `auth-schema` depend on `auth-relations`, which depends back on `auth-schema`. The bundler flattens the cycle into one chunk and, depending on platform/ordering, evaluates the relations before the tables — a classic TDZ bug. It works in dev (lazy resolution) and in some local builds, but fails in the Linux/Docker production bundle.
+
+## What Changes
+
+- Delete the trailing re-export block in `src/lib/db/schemas/auth-schema.ts` (lines 145-149).
+- In `src/lib/db/schemas/index.ts`, split the auth export into two lines:
+  - `export { user, session, account, verification } from './auth-schema'`
+  - `export { userRelations, sessionRelations, accountRelations } from './auth-relations'`
+- Dependency direction becomes one-way: `auth-relations → auth-schema` (tables), with `index.ts` importing relations directly from `auth-relations`. No cycle.
+- Public symbols remain identical — only the module that re-exports the relations changes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. Internal module-structure refactor; external behavior unchanged. Declared via `skip_specs: true` in `.openspec.yaml`.
+
+## Impact
+
+- `src/lib/db/schemas/auth-schema.ts` — removes the relations re-export (fixes the cycle).
+- `src/lib/db/schemas/index.ts` — imports relations from `./auth-relations` directly.
+- No other file imports the relations from `auth-schema` (verified: only the barrel does), so no consumer breaks.
+- Production Docker image must be rebuilt (new release tag) to pick up the fix.

--- a/openspec/changes/fix-auth-schema-circular-import/tasks.md
+++ b/openspec/changes/fix-auth-schema-circular-import/tasks.md
@@ -7,5 +7,5 @@
 ## 2. Verify and release
 
 - [x] 2.1 Confirm no other file imports the relations from `auth-schema` (grep) and the public export surface is unchanged
-- [ ] 2.2 Run the Verification gate and build with `ASTRO_ADAPTER=bun`, confirming the produced chunk orders `const user` before the `relations(user, ...)` calls
+- [x] 2.2 Run the Verification gate and build with `ASTRO_ADAPTER=bun`, confirming the produced chunk orders `const user` before the `relations(user, ...)` calls
 - [ ] 2.3 Open a PR to `master` on branch `fix/auth-schema-circular-import`, run `bun run release:patch` on the branch, merge, and push the tag to rebuild the Docker image

--- a/openspec/changes/fix-auth-schema-circular-import/tasks.md
+++ b/openspec/changes/fix-auth-schema-circular-import/tasks.md
@@ -1,0 +1,11 @@
+## 1. Break the auth schema circular import
+
+- [x] 1.1 Remove the trailing relations re-export block (lines 145-149) from `src/lib/db/schemas/auth-schema.ts`
+- [x] 1.2 Split the auth export in `src/lib/db/schemas/index.ts`: tables from `./auth-schema`, relations from `./auth-relations`
+- [x] 1.3 Update the `@module` doc blocks to reflect the new dependency direction (`auth-schema` no longer re-exports relations; `index.ts` sources relations from `auth-relations`)
+
+## 2. Verify and release
+
+- [x] 2.1 Confirm no other file imports the relations from `auth-schema` (grep) and the public export surface is unchanged
+- [ ] 2.2 Run the Verification gate and build with `ASTRO_ADAPTER=bun`, confirming the produced chunk orders `const user` before the `relations(user, ...)` calls
+- [ ] 2.3 Open a PR to `master` on branch `fix/auth-schema-circular-import`, run `bun run release:patch` on the branch, merge, and push the tag to rebuild the Docker image

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anidev-v2",
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/lib/db/schemas/auth-schema.ts
+++ b/src/lib/db/schemas/auth-schema.ts
@@ -2,8 +2,8 @@
  * @module lib/db/schemas/auth-schema
  *
  * Better Auth persistence layer: user accounts, sessions, linked OAuth/credential
- * accounts, and verification tokens. Includes Drizzle relation helpers for
- * eager-loading sessions and accounts from a user root.
+ * accounts, and verification tokens. Drizzle relation helpers live in the
+ * sibling `auth-relations` module, which imports the tables from here.
  *
  * @remarks
  * Table and column names follow Better Auth Drizzle adapter conventions.
@@ -11,6 +11,7 @@
  * deletes on `userId` foreign keys remove orphaned sessions and accounts.
  *
  * @see {@link module:lib/auth/server} for adapter registration
+ * @see {@link module:lib/db/schemas/auth-relations} for the relation graph
  * @see {@link module:lib/db/schemas/profile} for extended user profile data
  */
 import { sql } from 'drizzle-orm'
@@ -51,7 +52,7 @@ export const user = pgTable('user', {
  * - `expiresAt` — Hard expiry; expired tokens must be rejected.
  * - `userId` — FK to {@link user.id}; indexed for lookup by user.
  *
- * @see {@link sessionRelations} for Drizzle `user` join
+ * @see {@link module:lib/db/schemas/auth-relations.sessionRelations} for Drizzle `user` join
  */
 export const session = pgTable(
   'session',
@@ -83,7 +84,7 @@ export const session = pgTable(
  * - `password` — Hashed credential for email/password provider when present.
  * - Token columns — OAuth access/refresh tokens and expiry metadata.
  *
- * @see {@link accountRelations} for Drizzle `user` join
+ * @see {@link module:lib/db/schemas/auth-relations.accountRelations} for Drizzle `user` join
  */
 export const account = pgTable(
   'account',
@@ -141,9 +142,3 @@ export const verification = pgTable(
   },
   (table) => [index('verification_identifier_idx').on(table.identifier)]
 )
-
-export {
-  accountRelations,
-  sessionRelations,
-  userRelations,
-} from '@db/schemas/auth-relations'

--- a/src/lib/db/schemas/index.ts
+++ b/src/lib/db/schemas/index.ts
@@ -4,7 +4,8 @@
  * Named re-exports of all Drizzle ORM schema definitions for the AniDev
  * PostgreSQL database. Tables cover authentication (Better Auth), anime catalog
  * metadata, related media entities, junction relations, and extended user
- * profiles.
+ * profiles. Relation graphs are re-exported from their own modules (e.g.
+ * `./auth-relations`) to avoid circular imports with the table definitions.
  *
  * @remarks
  * Import from `@db/schemas` when repositories need multiple table symbols.
@@ -32,15 +33,12 @@ export {
 } from './anime-taxonomy-relations'
 export { genre, theme, demographic } from './anime-taxonomy'
 export { artist } from './artist'
+export { user, session, account, verification } from './auth-schema'
 export {
-  user,
-  session,
-  account,
-  verification,
   userRelations,
   sessionRelations,
   accountRelations,
-} from './auth-schema'
+} from './auth-relations'
 export { character, characterNickname } from './character'
 export { characterMedia } from './character-media'
 export { characterVoiceActor } from './character-relations'


### PR DESCRIPTION
## Why
Production crashes with `ReferenceError: Cannot access 'user' before initialization`. The build chunk `auth-schema_*.mjs` hoisted the Drizzle `relations(user, ...)` calls before the `const user` table declarations — a TDZ bug caused by a circular import:

- `auth-relations.ts` imports `{ account, session, user }` from `auth-schema.ts`
- `auth-schema.ts` re-exported `{ userRelations, sessionRelations, accountRelations }` from `auth-relations.ts` (bottom of file)

## What
- Removed the trailing relations re-export from `src/lib/db/schemas/auth-schema.ts`
- Split the barrel export in `src/lib/db/schemas/index.ts`: tables from `./auth-schema`, relations from `./auth-relations`
- Updated `@module`/`@see` JSDoc to reflect the one-way dependency (`auth-relations → auth-schema`)
- Public export surface unchanged; no consumer imports relations from `auth-schema` (verified by grep)

## Verification
- Gate: format ✓ check ✓ check:types ✓ test (41) ✓ build ✓
- `ASTRO_ADAPTER=bun` build: the produced `auth-schema_*.mjs` chunk now declares `const user` first, with no `relations(...)` calls before the tables — TDZ eliminated

## Release
Bump 0.1.2 → 0.1.3 (patch, `fix(db)`) rides on this branch with tag `v0.1.3`, so the merge triggers a Docker image rebuild via `release.yml`.