### PR TITLE
feat(api): Add public health check endpoint with info logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.2.0](https://github.com/Sebas200702/anidev-v2/compare/v0.1.3...v0.2.0) (2026-08-08)
+
+
+### Features
+
+* **api:** Add public health check endpoint with info logging ([7a81bf2](https://github.com/Sebas200702/anidev-v2/commit/7a81bf29898502613f5c54a5797f6f21385daef7))
+
 ### [0.1.3](https://github.com/Sebas200702/anidev-v2/compare/v0.1.2...v0.1.3) (2026-08-07)
 
 

--- a/openspec/changes/add-health-endpoint/.openspec.yaml
+++ b/openspec/changes/add-health-endpoint/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/add-health-endpoint/design.md
+++ b/openspec/changes/add-health-endpoint/design.md
@@ -1,0 +1,33 @@
+## Context
+
+See proposal.md - Why. The monitoring layer already bridges Pino logs to the Sentry/Rustrak backend via `pinoIntegration` (`src/lib/monitoring/sentry.ts:62,94`), and the app logger is a Pino singleton at `src/shared/utils/logger-util.ts`. A public health route is the smallest surface to exercise that pipeline deterministically.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose `GET /api/health` as a public, unauthenticated liveness route.
+- Emit one `info`-level structured log per request so the pino→Sentry→Rustrak pipeline can be verified end-to-end.
+- Follow the existing API route conventions (envelope, error mapping, JSDoc).
+
+**Non-Goals:**
+
+- No health-check of external dependencies (DB/cache) — liveness only, matching the smoke-test purpose.
+- No auth changes, schema changes, or new dependencies.
+- No changes to the monitoring SDK wiring itself.
+
+## Decisions
+
+**Plain handler with `withErrorHandling`.**
+The route has no params/query/body to validate, so `withZodValidation` adds nothing. Use `withErrorHandling` for consistent envelope + error mapping, or a plain `APIRoute` with a manual try/catch like `src/pages/api/music/index.ts`. Keep it a plain handler returning `createSuccessResponse` with `{ status: 'ok' }`; emit `logger.info({ route: '/api/health' }, 'Health check requested')` before returning.
+
+**Add `/api/health` to `publicRoutes`.**
+Matching is prefix-based (`isPublicRoute`); adding the exact route string is sufficient and consistent with `/api/music`, `/api/anime`.
+
+**Log level `info`.**
+Matches the production default (`logger` runs at `info` in `NODE_ENV=production`, `src/shared/utils/logger-util.ts:33`), so the log is actually forwarded in production rather than being dropped at `debug`.
+
+## Risks / Trade-offs
+
+- A health endpoint can be called frequently and spam logs → the log line is single and short; if it becomes noisy, add a sampling flag later (out of scope).
+- Public liveness routes are harmless — they expose no data, only `200` + `status: ok`.

--- a/openspec/changes/add-health-endpoint/proposal.md
+++ b/openspec/changes/add-health-endpoint/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Rustrak shows "Events: 0" even with `SENTRY_DSN` configured and the container restarted. The pino→Sentry→Rustrak log pipeline needs an end-to-end smoke test: a way to deterministically emit an `info`-level log and confirm it lands in Rustrak. There is currently no route that does this.
+
+## What Changes
+
+- Add a public `GET /api/health` API route that:
+  - Returns `200 OK` with the standard envelope (`{ data, status }`).
+  - Emits an `info`-level structured log via the app logger (`@utils/logger-util`) each time it is called, which the pino → Sentry bridge (`pinoIntegration`) forwards to Rustrak when a DSN is set.
+- Register `/api/health` in `src/config/public-routes.ts` so it is reachable without a session.
+- Add a Vitest test asserting the route logs at `info` level and returns the expected envelope (TDD).
+
+## Capabilities
+
+### New Capabilities
+
+- `infrastructure/monitoring`: Add a requirement for a public health endpoint that exercises the log pipeline by emitting an `info`-level log on each request.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `src/pages/api/health.ts` — new route.
+- `src/config/public-routes.ts` — add `/api/health` to the allowlist.
+- `src/shared/__tests__/` or route-level `__tests__` — new Vitest coverage.
+- No dependency, schema, or auth changes.

--- a/openspec/changes/add-health-endpoint/specs/infrastructure/monitoring/spec.md
+++ b/openspec/changes/add-health-endpoint/specs/infrastructure/monitoring/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+
+Provides a public health endpoint that returns service liveness and deterministically exercises the structured log pipeline, so the Pino → Sentry/Rustrak bridge can be verified end-to-end.
+
+## ADDED Requirements
+
+### Requirement: Public health endpoint
+The system SHALL expose a public `GET /api/health` route that is reachable without authentication and returns a `200 OK` response using the standard API envelope.
+
+#### Scenario: Health request succeeds
+- **WHEN** a client requests `GET /api/health` without a session
+- **THEN** the route responds `200` with a JSON envelope containing `data` and `status: 200`
+
+#### Scenario: Health route is public
+- **WHEN** the auth middleware evaluates `/api/health`
+- **THEN** the pathname is treated as public and does not require a session
+
+### Requirement: Health check emits an info log
+The health endpoint SHALL emit an `info`-level structured log via the application logger on every request, which is forwarded to the configured monitoring backend through the Pino bridge.
+
+#### Scenario: Info log emitted on health call
+- **WHEN** a client requests `GET /api/health` and the monitoring DSN is configured
+- **THEN** the logger records an `info`-level event that the monitoring bridge forwards to the backend
+
+#### Scenario: Info log emitted without DSN
+- **WHEN** a client requests `GET /api/health` and no monitoring DSN is configured
+- **THEN** the endpoint still logs to stdout at `info` level without throwing

--- a/openspec/changes/add-health-endpoint/tasks.md
+++ b/openspec/changes/add-health-endpoint/tasks.md
@@ -9,6 +9,6 @@
 
 ## 3. Verify and release
 
-- [ ] 3.1 Run the Verification gate (`format → check → check:types → test → build`)
-- [ ] 3.2 Smoke-test locally with `ASTRO_ADAPTER=bun` (dev or built server) hitting `/api/health` and confirming the `info` log line appears
+- [x] 3.1 Run the Verification gate (`format → check → check:types → test → build`)
+- [x] 3.2 Smoke-test locally with `ASTRO_ADAPTER=bun` (dev or built server) hitting `/api/health` and confirming the `info` log line appears
 - [ ] 3.3 Open a PR to `master` on branch `feat/health-endpoint`, run `bun run release:minor` on the branch, merge, and push the tag to rebuild the Docker image; then confirm the request appears in Rustrak

--- a/openspec/changes/add-health-endpoint/tasks.md
+++ b/openspec/changes/add-health-endpoint/tasks.md
@@ -1,0 +1,14 @@
+## 1. Health route (TDD)
+
+- [x] 1.1 Write a failing Vitest test for `GET /api/health`: it calls the handler, asserts `200` with envelope `{ data: { status: 'ok' }, status: 200 }`, and asserts the logger records an `info`-level message (spy on `logger.info`)
+- [x] 1.2 Implement `src/pages/api/health.ts`: public `GET` route that logs `info` and returns the envelope (JSDoc `@module`, response/error contract)
+
+## 2. Public route registration
+
+- [x] 2.1 Add `/api/health` to `publicRoutes` in `src/config/public-routes.ts` and update the `@module`/`@remarks` docs
+
+## 3. Verify and release
+
+- [ ] 3.1 Run the Verification gate (`format → check → check:types → test → build`)
+- [ ] 3.2 Smoke-test locally with `ASTRO_ADAPTER=bun` (dev or built server) hitting `/api/health` and confirming the `info` log line appears
+- [ ] 3.3 Open a PR to `master` on branch `feat/health-endpoint`, run `bun run release:minor` on the branch, merge, and push the tag to rebuild the Docker image; then confirm the request appears in Rustrak

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anidev-v2",
   "type": "module",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/config/public-routes.ts
+++ b/src/config/public-routes.ts
@@ -10,8 +10,8 @@
  * Matching is prefix-based: a pathname is public if it equals a listed route
  * or starts with `{route}/`. Trailing slashes on the incoming pathname are
  * not normalized; callers should pass `context.url.pathname` as-is. API list
- * endpoints under `/api/anime` and `/api/music` are intentionally public for
- * browse-before-login flows.
+ * endpoints under `/api/anime` and `/api/music`, plus the `/api/health` liveness
+ * check, are intentionally public for browse-before-login flows and monitoring.
  *
  * @see {@link module:middleware/auth-middleware} for runtime enforcement
  * @see {@link isPublicRoute} for the matching helper
@@ -32,6 +32,7 @@ export const publicRoutes = [
   '/api/auth/register',
   '/api/anime',
   '/api/music',
+  '/api/health',
   '/media',
 ] as const
 

--- a/src/pages/api/__tests__/health.test.ts
+++ b/src/pages/api/__tests__/health.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for the public health check route.
+ *
+ * @module pages/api/__tests__/health
+ * @remarks
+ * `src/config/env.ts` validates eagerly at import, so this test mocks it with
+ * `vi.mock('@config/env')` (the runner does not load `.env`). The handler under
+ * test is the raw `GET` route from {@link module:pages/api/health}; it is
+ * invoked directly with a minimal `APIContext` and the response parsed as JSON.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@config/env', () => ({
+  env: {
+    NODE_ENV: 'production',
+    LOG_LEVEL: 'info',
+    SENTRY_DSN: undefined,
+  },
+}))
+
+import { logger } from '@utils/logger-util'
+import { GET } from '../health'
+
+const createContext = () =>
+  ({
+    request: new Request('http://localhost:4321/api/health'),
+    params: {},
+  }) as Parameters<typeof GET>[0]
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('GET /api/health', () => {
+  it('responds 200 with the standard success envelope', async () => {
+    const response = await GET(createContext())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      data: { status: 'ok' },
+      status: 200,
+    })
+  })
+
+  it('emits an info-level log on each request', async () => {
+    const infoSpy = vi.spyOn(logger, 'info')
+
+    await GET(createContext())
+
+    expect(infoSpy).toHaveBeenCalledTimes(1)
+    expect(infoSpy.mock.calls[0][0]).toEqual({ route: '/api/health' })
+  })
+})

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,48 @@
+/**
+ * Public health check endpoint.
+ *
+ * @module pages/api/health
+ *
+ * **Route:** `GET /api/health`
+ *
+ * **Authentication:** Public — no session required ({@link isPublicRoute} allowlists `/api/health`).
+ *
+ * Returns a liveness envelope and emits an `info`-level structured log on every
+ * request. The log flows through the Pino → Sentry/Rustrak bridge
+ * ({@link module:lib/monitoring/sentry}) when a monitoring DSN is configured,
+ * which makes this endpoint a deterministic end-to-end smoke test for the log
+ * pipeline.
+ *
+ * @see {@link logger} — app logger that forwards to the monitoring bridge
+ * @see {@link module:lib/monitoring/sentry} — pinoIntegration bridge to Rustrak
+ * @see {@link withErrorHandling} — standardized JSON envelope wrapper
+ */
+
+import { logger } from '@utils/logger-util'
+import { withErrorHandling } from '@http/with-error-handling'
+
+/**
+ * Returns `200 OK` with `{ status: 'ok' }` and logs the check at `info` level.
+ *
+ * @remarks
+ * **Success response — `200 OK`**
+ *
+ * ```typescript
+ * {
+ *   data: { status: 'ok' }
+ *   status: 200
+ *   meta: {}
+ * }
+ * ```
+ *
+ * @example
+ * ```bash
+ * curl http://localhost:4321/api/health
+ * # {"data":{"status":"ok"},"status":200,"meta":{}}
+ * ```
+ */
+export const GET = withErrorHandling(async () => {
+  logger.info({ route: '/api/health' }, 'Health check requested')
+
+  return { data: { status: 'ok' }, status: 200 }
+})


### PR DESCRIPTION
## Why
Rustrak shows 'Events: 0' even with SENTRY_DSN set. There is no way to deterministically verify the Pino → Sentry → Rustrak log pipeline. This adds a public liveness endpoint that emits an `info` log per request as an end-to-end smoke test.

## What
- **GET /api/health** — public, unauthenticated, returns `200` with envelope `{ data: { status: 'ok' }, status: 200 }`.
- Emits `logger.info({ route: '/api/health' }, 'Health check requested')` on every call, forwarded to Rustrak via the `pinoIntegration` bridge when a DSN is set.
- Registered `/api/health` in `src/config/public-routes.ts`.
- TDD: Vitest test asserting envelope + `info` log emission (mocks `@config/env` eager validation).

## Verification
- Gate passed locally: format ✓ check ✓ check:types ✓ test (43) ✓ build ✓
- Smoke test on `ASTRO_ADAPTER=bun` built server: `200` + `INFO Health check requested` log.
- Docker end-to-end: image built with `ASTRO_ADAPTER=bun`, container served `200`, and Rustrak local received `POST /api/1/envelope/` (sentry.javascript.astro) — pipeline confirmed.

## Note (observed, not changed)
`sentry.server.config` loads as a side-effect on page chunks (e.g. home), not on the health chunk alone — Sentry initializes on first page render. No code change made here; flagged for follow-up.

## Release
Bump 0.1.3 → **0.2.0** (minor, `feat(api)`) rides on this branch with tag `v0.2.0` so merging triggers a Docker image rebuild via `release.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public `GET /api/health` endpoint for service liveness checks.
  * Returns a successful response with `{ status: "ok" }` without authentication.
  * Records an informational log for each health-check request.
* **Documentation**
  * Documented the new health-check endpoint and monitoring behavior.
* **Chores**
  * Updated the release version to `0.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->