### PR TITLE
fix(monitoring): Initialize Sentry before API requests via middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.1](https://github.com/Sebas200702/anidev-v2/compare/v0.2.0...v0.2.1) (2026-08-08)
+
+
+### Bug Fixes
+
+* **monitoring:** Initialize Sentry before API requests via middleware ([1ea8567](https://github.com/Sebas200702/anidev-v2/commit/1ea856737b31d296b475bda0c3bcc54178d2d541))
+
 ## [0.2.0](https://github.com/Sebas200702/anidev-v2/compare/v0.1.3...v0.2.0) (2026-08-08)
 
 

--- a/openspec/changes/fix-sentry-server-init-on-api-routes/.openspec.yaml
+++ b/openspec/changes/fix-sentry-server-init-on-api-routes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/fix-sentry-server-init-on-api-routes/design.md
+++ b/openspec/changes/fix-sentry-server-init-on-api-routes/design.md
@@ -1,0 +1,36 @@
+## Context
+
+See proposal.md - Why. `@sentry/astro` injects `sentry.server.config` via `injectScript('page-ssr', ...)` (confirmed in `node_modules/@sentry/astro/build/esm/integration/index.js`), so `initAstroSentry()` runs only on SSR page renders, never for API endpoints. The health endpoint verified this: Rustrak received `POST /api/1/envelope/` only after loading a page, never from `/api/health` alone.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Initialize the monitoring SDK before any route handler — page or API — runs.
+- Make `initAstroSentry()` idempotent so middleware + page injection don't double-init.
+- Keep no-op behavior when `SENTRY_DSN` is unset.
+
+**Non-Goals:**
+
+- No changes to the DSN, SDK versions, or the `sentry.server.config` bootstrap.
+- No changes to log leveling or the pino bridge itself.
+- No changes to the API route patterns.
+
+## Decisions
+
+**Initialize from the Astro middleware module.**
+The session middleware (`src/middleware/auth-middleware.ts`, registered in `astro.config.mjs` via `sessionMiddlewareIntegration`) runs on every request — pages and API endpoints. Adding a module-level `initAstroSentry()` import there guarantees SDK init before any handler, independent of `@sentry/astro`'s page-only injection.
+
+Alternative considered: importing the bootstrap in each API route — rejected, too invasive and error-prone (every new route must remember to import it). Alternative: importing `sentry.server.config` from a shared barrel — rejected, middleware is the single always-executed entry point.
+
+**Guard `initAstroSentry()` for idempotency.**
+Both the middleware and `@sentry/astro`'s page injection will call it. A module-level `isInitialized` flag (or checking SDK state) makes the second call a no-op. `initServerSentry` already effectively guards via SDK init semantics, but the explicit flag keeps behavior deterministic and testable.
+
+**Call `initAstroSentry()` (not `initServerSentry`) in the middleware.**
+The middleware is Astro SSR context, matching the `initAstroSentry` SDK variant already used by `sentry.server.config.ts`.
+
+## Risks / Trade-offs
+
+- Middleware now has a monitoring side effect → it's an explicit, documented import with a guard; no new failure surface since init never throws and no-ops without DSN.
+- Page + middleware double-call → the idempotency guard makes it a single init; covered by a new test.
+- The health endpoint remains page-independent, so production logs flow to Rustrak on first API call — closing the "Events: 0" gap.

--- a/openspec/changes/fix-sentry-server-init-on-api-routes/proposal.md
+++ b/openspec/changes/fix-sentry-server-init-on-api-routes/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `GET /api/health` endpoint logs at `info` level on every request, but in production the log never reaches Rustrak. Root cause: `@sentry/astro` injects `sentry.server.config` only via `injectScript('page-ssr', ...)`, so the SDK initializes (`initAstroSentry()`) only when an SSR **page** (`.astro`) renders — never for **API endpoints** (`src/pages/api/*.ts`). If the first request is `/api/health` (or any API route), `initAstroSentry()` never runs and the pino→Sentry bridge is never wired, so logs stay in stdout only.
+
+## What Changes
+
+- Ensure `initAstroSentry()` runs before any route handling, including API endpoints, by calling it at Astro **middleware** startup (the middleware module already executes on every request — page or API).
+- The middleware module imports the monitoring bootstrap; `initAstroSentry()` stays idempotent/no-op when `SENTRY_DSN` is unset (unchanged behavior).
+- Keep `sentry.server.config` as-is for page-side injection (harmless duplicate; `initAstroSentry` must tolerate being called twice).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `infrastructure/monitoring`: Add requirement that the monitoring SDK initializes before any request (page or API) is handled.
+
+## Impact
+
+- `src/middleware/auth-middleware.ts` — import + call the monitoring init at module load (middleware runs for all routes).
+- `src/lib/monitoring/sentry.ts` — make `initAstroSentry` idempotent (guard against double-init from page + middleware).
+- `src/lib/monitoring/__tests__/sentry.test.ts` — extend coverage for the double-init guard.
+- No DSN, SDK, or route changes.

--- a/openspec/changes/fix-sentry-server-init-on-api-routes/specs/infrastructure/monitoring/spec.md
+++ b/openspec/changes/fix-sentry-server-init-on-api-routes/specs/infrastructure/monitoring/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+
+Provides self-hosted error and performance monitoring compatible with the Sentry SDK surface, so error and trace reporting works against Rustrak (or any Sentry-SDK-compatible backend) while remaining a no-op when a DSN is absent.
+
+## MODIFIED Requirements
+
+### Requirement: Sentry-SDK-compatible monitoring init
+The system SHALL expose `initServerSentry`, `initAstroSentry`, and `wrapReactComponentWithSentry` functions that initialize monitoring using the Sentry SDK pointed at a configurable DSN, and no-op when the DSN is unset.
+
+#### Scenario: Monitoring enabled
+- **WHEN** a valid monitoring DSN is configured
+- **THEN** server and Astro contexts initialize the SDK with the environment profile and the React wrapper attaches an error boundary
+
+#### Scenario: Monitoring disabled no-ops
+- **WHEN** no DSN is configured
+- **THEN** all monitoring functions return without side effects and the React wrapper passes the component through unchanged
+
+### Requirement: Monitoring initializes before any request handling
+The Astro server SHALL initialize the monitoring SDK before handling any request, including API endpoints, so log bridging and error capture are active for page and API traffic alike.
+
+#### Scenario: API endpoint triggers SDK init
+- **WHEN** the first request to the running server is an API endpoint (e.g. `GET /api/health`)
+- **THEN** the SDK is initialized before the endpoint handler runs and logs from that handler are forwarded to the backend
+
+#### Scenario: Page and middleware both call init
+- **WHEN** both the Astro middleware and an SSR page attempt to initialize the SDK
+- **THEN** the SDK is initialized exactly once and subsequent calls are no-ops

--- a/openspec/changes/fix-sentry-server-init-on-api-routes/tasks.md
+++ b/openspec/changes/fix-sentry-server-init-on-api-routes/tasks.md
@@ -1,0 +1,14 @@
+## 1. Idempotent monitoring init (TDD)
+
+- [x] 1.1 Write a failing Vitest test in `src/lib/monitoring/__tests__/sentry.test.ts`: calling `initAstroSentry()` twice with a DSN invokes `SentryAstro.init` exactly once (guard works)
+- [x] 1.2 Add a module-level `hasInitialized` guard to `initAstroSentry` in `src/lib/monitoring/sentry.ts` (no-op on repeat calls)
+
+## 2. Initialize monitoring in the middleware
+
+- [x] 2.1 Import and call `initAstroSentry()` at module load in `src/middleware/auth-middleware.ts`, updating its `@module` doc
+
+## 3. Verify and release
+
+- [ ] 3.1 Run the Verification gate (`format → check → check:types → test → build`)
+- [ ] 3.2 Build with `ASTRO_ADAPTER=bun` and smoke-test that `/api/health` alone (without loading any page) forwards the log to local Rustrak
+- [ ] 3.3 Open a PR to `master` on branch `fix/sentry-server-init-on-api-routes`, run `bun run release:patch` on the branch, merge, and push the tag to rebuild the Docker image

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anidev-v2",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/lib/monitoring/__tests__/sentry.test.ts
+++ b/src/lib/monitoring/__tests__/sentry.test.ts
@@ -99,4 +99,14 @@ describe('monitoring log capture', () => {
     )
     expect(sentryAstroPino).toHaveBeenCalled()
   })
+
+  it('initializes the Astro SDK exactly once across repeated calls', async () => {
+    mockEnv.SENTRY_DSN = 'http://key@localhost:8080/1'
+    const { initAstroSentry } = await loadSentry()
+
+    initAstroSentry()
+    initAstroSentry()
+
+    expect(sentryAstroInit).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/lib/monitoring/sentry.ts
+++ b/src/lib/monitoring/sentry.ts
@@ -31,6 +31,13 @@ import { env } from '@config/env'
 const isEnabled = !!env.SENTRY_DSN
 
 /**
+ * Guards against double-initializing the Astro SDK. Both the session middleware
+ * and `@sentry/astro`'s page-ssr injection call {@link initAstroSentry}; the flag
+ * makes repeat calls no-ops.
+ */
+let hasInitialized = false
+
+/**
  * Initializes Sentry for Node/server-side error and trace reporting.
  *
  * @returns `void`. Side effect: registers Sentry Node SDK when enabled.
@@ -85,6 +92,8 @@ export const initServerSentry = () => {
  */
 export const initAstroSentry = () => {
   if (!isEnabled) return
+  if (hasInitialized) return
+  hasInitialized = true
 
   SentryAstro.init({
     dsn: env.SENTRY_DSN,

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -16,10 +16,18 @@
  * @see {@link module:config/public-routes} for routes that skip session enforcement
  * @see {@link module:types/env.d} for `App.Locals` typing
  * @see {@link module:lib/auth/server} for the Better Auth server instance
+ * @see {@link module:lib/monitoring/sentry.initAstroSentry} for the monitoring bootstrap
  */
 import { defineMiddleware } from 'astro:middleware'
 import { isPublicRoute } from '@config/public-routes'
 import { resolveAuthActor } from '@auth/middleware'
+import { initAstroSentry } from '@lib/monitoring/sentry'
+
+// Initialize monitoring at middleware load so the SDK is active before any
+// request — page or API endpoint — is handled. `@sentry/astro` only injects
+// `sentry.server.config` on page renders, so API-first traffic would otherwise
+// never wire the pino bridge. No-op when SENTRY_DSN is unset.
+initAstroSentry()
 
 /** Cookie substrings that indicate a Better Auth session may be present. */
 const authCookieMarkers = ['session_token=', 'session_data=']


### PR DESCRIPTION
## Why
In production, logs never reach Rustrak when traffic starts with API calls. `@sentry/astro` injects `sentry.server.config` only via `injectScript('page-ssr', ...)`, so `initAstroSentry()` runs only on SSR page renders — never for API endpoints (`src/pages/api/*.ts`). `GET /api/health` alone never wired the pino→Sentry bridge.

## What
- `src/middleware/auth-middleware.ts`: call `initAstroSentry()` at module load — the middleware runs before every request (page or API), so the SDK is active before any handler.
- `src/lib/monitoring/sentry.ts`: add a `hasInitialized` guard so repeat calls (middleware + page-ssr injection) init the SDK exactly once.
- TDD: new test asserting `initAstroSentry()` called twice → `SentryAstro.init` once.

## Verification
- Gate passed locally: format ✓ check ✓ check:types ✓ test (44) ✓ build ✓
- Smoke test: `ASTRO_ADAPTER=bun` server hit with **only** `GET /api/health` (no page load) → local Rustrak received `POST /api/1/envelope/` → 200. SDK now initializes for API-first traffic.

## Release
Bump 0.2.0 → **0.2.1** (patch, `fix(monitoring)`) rides on this branch with tag `v0.2.1` so merging triggers a Docker image rebuild via `release.yml`.