### PR TITLE
fix(monitoring): Emit explicit Sentry event from health check endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.2](https://github.com/Sebas200702/anidev-v2/compare/v0.2.1...v0.2.2) (2026-08-08)
+
+
+### Bug Fixes
+
+* **monitoring:** Emit explicit Sentry event from health check endpoint ([9b40265](https://github.com/Sebas200702/anidev-v2/commit/9b402659eb234f468fcec715f98d48d797759723))
+
 ### [0.2.1](https://github.com/Sebas200702/anidev-v2/compare/v0.2.0...v0.2.1) (2026-08-08)
 
 

--- a/openspec/changes/add-sentry-capture-to-health-check/.openspec.yaml
+++ b/openspec/changes/add-sentry-capture-to-health-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/add-sentry-capture-to-health-check/design.md
+++ b/openspec/changes/add-sentry-capture-to-health-check/design.md
@@ -1,0 +1,35 @@
+## Context
+
+See proposal.md - Why. The health endpoint already logs via Pino (`logger.info`) and the pino→Sentry bridge is configured (`enableLogs: true` + `pinoIntegration()`). In production the log reaches stdout but no envelope reaches Rustrak, leaving two hypotheses: broken log bridge vs SDK not initializing. Adding an explicit `Sentry.captureMessage` produces a deterministic, bridge-independent signal.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Emit an explicit Sentry event from the health endpoint on every request.
+- Disambiguate production connectivity issues: bridge problem vs SDK-init problem.
+- Keep the endpoint behavior (200 envelope) unchanged.
+
+**Non-Goals:**
+
+- No changes to the monitoring init, DSN, or pino bridge.
+- No changes to the existing Pino log line.
+- No log-level changes.
+
+## Decisions
+
+**Use `Sentry.captureMessage` via the `@sentry/astro` namespace.**
+`@sentry/astro` (v10.43.0, server entry) re-exports `captureMessage` from `@sentry/node`, so `import * as Sentry from '@sentry/astro'` exposes it. It sends an `event`-type envelope (message) to the DSN — distinct from log envelopes — so Rustrak issues view shows it even if log capture is misconfigured.
+
+Alternative considered: `Sentry.logger.info(...)` — rejected, it exercises the same log path as the bridge, defeating the disambiguation goal. `captureMessage` is the correct bridge-independent probe.
+
+**Call it after the logger line, fire-and-forget.**
+`captureMessage` is non-blocking and safe when the SDK is uninitialized (no-op). No await needed. If `SENTRY_DSN` is unset, `isEnabled` is false and init never runs, but `captureMessage` on an uninitialized SDK no-ops without throwing — preserving the health endpoint's contract.
+
+**Guard in tests with the same `@sentry/astro` mock.**
+The existing health test mocks `@config/env`; extend it to also mock `@sentry/astro`'s `captureMessage` and assert it is called once per request.
+
+## Risks / Trade-offs
+
+- A `captureMessage` per health call could spam Rustrak if health checks are frequent → the endpoint is explicitly a smoke test; acceptable volume. Add sampling later if needed (out of scope).
+- `captureMessage` default level is `info`; if Rustrak groups messages as issues, each distinct call may create an issue → use a stable `message` string so it groups into one issue.

--- a/openspec/changes/add-sentry-capture-to-health-check/proposal.md
+++ b/openspec/changes/add-sentry-capture-to-health-check/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+In production the `GET /api/health` endpoint responds `200` and writes the Pino log line to stdout, but no envelope reaches Rustrak. The Pino→Sentry log bridge depends on `enableLogs: true` + `pinoIntegration()` (both configured), so if the SDK initializes, logs should flow. There is no way to tell from the app side whether the problem is (a) the log bridge, or (b) the SDK never initializing in the deployed container. An explicit `Sentry.captureMessage(...)` on the health endpoint disambiguates: if it appears in Rustrak → SDK + transport work and the issue is the pino bridge; if it does not → the SDK is not initializing (stale image or missing/unreachable DSN).
+
+## What Changes
+
+- Add an explicit `Sentry.captureMessage('Health check', { ... })` call in `GET /api/health`, alongside the existing `logger.info(...)`.
+- Keep the pino log (unchanged) — the capture is additive.
+- No changes to the monitoring init, DSN, or pino bridge.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `infrastructure/monitoring`: Add requirement that the health endpoint emits an explicit Sentry event on each request to verify end-to-end connectivity independent of the pino bridge.
+
+## Impact
+
+- `src/pages/api/health.ts` — add the `captureMessage` call + JSDoc.
+- `src/pages/api/__tests__/health.test.ts` — assert `captureMessage` is invoked on request.
+- No DSN, SDK version, or init changes.

--- a/openspec/changes/add-sentry-capture-to-health-check/specs/infrastructure/monitoring/spec.md
+++ b/openspec/changes/add-sentry-capture-to-health-check/specs/infrastructure/monitoring/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+
+Provides self-hosted error and performance monitoring compatible with the Sentry SDK surface, so error and trace reporting works against Rustrak (or any Sentry-SDK-compatible backend) while remaining a no-op when a DSN is absent.
+
+## MODIFIED Requirements
+
+### Requirement: Sentry-SDK-compatible monitoring init
+The system SHALL expose `initServerSentry`, `initAstroSentry`, and `wrapReactComponentWithSentry` functions that initialize monitoring using the Sentry SDK pointed at a configurable DSN, and no-op when the DSN is unset.
+
+#### Scenario: Monitoring enabled
+- **WHEN** a valid monitoring DSN is configured
+- **THEN** server and Astro contexts initialize the SDK with the environment profile and the React wrapper attaches an error boundary
+
+#### Scenario: Monitoring disabled no-ops
+- **WHEN** no DSN is configured
+- **THEN** all monitoring functions return without side effects and the React wrapper passes the component through unchanged
+
+### Requirement: Health check emits an explicit Sentry event
+The public health endpoint SHALL emit an explicit Sentry event (`captureMessage`) on each request, independent of the Pino log bridge, to verify end-to-end connectivity to the configured monitoring backend.
+
+#### Scenario: Health request with DSN configured
+- **WHEN** a client requests `GET /api/health` and a monitoring DSN is configured
+- **THEN** the endpoint sends an explicit `captureMessage` event to the backend in addition to the Pino log
+
+#### Scenario: Health request without DSN
+- **WHEN** a client requests `GET /api/health` and no monitoring DSN is configured
+- **THEN** the endpoint still returns `200` and does not throw (Sentry no-ops)

--- a/openspec/changes/add-sentry-capture-to-health-check/tasks.md
+++ b/openspec/changes/add-sentry-capture-to-health-check/tasks.md
@@ -1,0 +1,10 @@
+## 1. Explicit Sentry event in health check (TDD)
+
+- [x] 1.1 Write a failing Vitest test in `src/pages/api/__tests__/health.test.ts`: `GET /api/health` invokes `Sentry.captureMessage` once with a stable message (mock `@sentry/astro`)
+- [x] 1.2 Add the `captureMessage` call to `GET /api/health` in `src/pages/api/health.ts`, alongside the existing `logger.info`, and update the `@module` doc
+
+## 2. Verify and release
+
+- [ ] 2.1 Run the Verification gate (`format → check → check:types → test → build`)
+- [ ] 2.2 Build with `ASTRO_ADAPTER=bun` and smoke-test that `/api/health` alone produces an `event` envelope to local Rustrak (in addition to the log envelope)
+- [ ] 2.3 Open a PR to `master` on branch `fix/health-sentry-capture`, run `bun run release:patch` on the branch, merge, and push the tag to rebuild the Docker image; then confirm `captureMessage` appears in production Rustrak

--- a/openspec/changes/add-sentry-capture-to-health-check/tasks.md
+++ b/openspec/changes/add-sentry-capture-to-health-check/tasks.md
@@ -5,6 +5,6 @@
 
 ## 2. Verify and release
 
-- [ ] 2.1 Run the Verification gate (`format → check → check:types → test → build`)
-- [ ] 2.2 Build with `ASTRO_ADAPTER=bun` and smoke-test that `/api/health` alone produces an `event` envelope to local Rustrak (in addition to the log envelope)
+- [x] 2.1 Run the Verification gate (`format → check → check:types → test → build`)
+- [x] 2.2 Build with `ASTRO_ADAPTER=bun` and smoke-test that `/api/health` alone produces an `event` envelope to local Rustrak (in addition to the log envelope)
 - [ ] 2.3 Open a PR to `master` on branch `fix/health-sentry-capture`, run `bun run release:patch` on the branch, merge, and push the tag to rebuild the Docker image; then confirm `captureMessage` appears in production Rustrak

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anidev-v2",
   "type": "module",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/pages/api/__tests__/health.test.ts
+++ b/src/pages/api/__tests__/health.test.ts
@@ -10,6 +10,12 @@
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
+const sentryMock = vi.hoisted(() => ({
+  captureMessage: vi.fn(),
+}))
+
+vi.mock('@sentry/astro', () => sentryMock)
+
 vi.mock('@config/env', () => ({
   env: {
     NODE_ENV: 'production',
@@ -29,6 +35,7 @@ const createContext = () =>
 
 beforeEach(() => {
   vi.restoreAllMocks()
+  sentryMock.captureMessage.mockClear()
 })
 
 describe('GET /api/health', () => {
@@ -49,5 +56,12 @@ describe('GET /api/health', () => {
 
     expect(infoSpy).toHaveBeenCalledTimes(1)
     expect(infoSpy.mock.calls[0][0]).toEqual({ route: '/api/health' })
+  })
+
+  it('emits an explicit Sentry event on each request', async () => {
+    await GET(createContext())
+
+    expect(sentryMock.captureMessage).toHaveBeenCalledTimes(1)
+    expect(sentryMock.captureMessage).toHaveBeenCalledWith('Health check')
   })
 })

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -11,13 +11,15 @@
  * request. The log flows through the Pino → Sentry/Rustrak bridge
  * ({@link module:lib/monitoring/sentry}) when a monitoring DSN is configured,
  * which makes this endpoint a deterministic end-to-end smoke test for the log
- * pipeline.
+ * pipeline. It also sends an explicit `captureMessage` event so connectivity can
+ * be verified independently of the Pino bridge.
  *
  * @see {@link logger} — app logger that forwards to the monitoring bridge
  * @see {@link module:lib/monitoring/sentry} — pinoIntegration bridge to Rustrak
  * @see {@link withErrorHandling} — standardized JSON envelope wrapper
  */
 
+import * as Sentry from '@sentry/astro'
 import { logger } from '@utils/logger-util'
 import { withErrorHandling } from '@http/with-error-handling'
 
@@ -43,6 +45,7 @@ import { withErrorHandling } from '@http/with-error-handling'
  */
 export const GET = withErrorHandling(async () => {
   logger.info({ route: '/api/health' }, 'Health check requested')
+  Sentry.captureMessage('Health check')
 
   return { data: { status: 'ok' }, status: 200 }
 })


### PR DESCRIPTION
## Why
In production `GET /api/health` responds `200` and logs via Pino to stdout, but no envelope reaches Rustrak. To disambiguate (broken pino bridge vs SDK not initializing), the health endpoint now emits an explicit Sentry event independent of the pino bridge.

## What
- `src/pages/api/health.ts`: add `Sentry.captureMessage('Health check')` alongside the existing `logger.info` — a stable message so Rustrak groups it into a single issue.
- TDD: health test asserts `captureMessage` is called once with the stable message (`vi.hoisted` mock of `@sentry/astro`).

## Verification
- Gate passed locally: format ✓ check ✓ check:types ✓ test (45) ✓ build ✓
- Smoke test: `ASTRO_ADAPTER=bun` server hit with **only** `GET /api/health` → Rustrak received `POST /api/1/envelope/` (sentry.javascript.astro) → 200.

## How to use (production)
If `captureMessage` appears in Rustrak → SDK + transport work, the issue was the pino log bridge. If it does not → the deployed container is stale (missing the middleware-init fix, v0.2.1) or `SENTRY_DSN` is unset/unreachable.

## Release
Bump 0.2.1 → **0.2.2** (patch, `fix(monitoring)`) rides on this branch with tag `v0.2.2` so merging triggers a Docker image rebuild via `release.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health-check monitoring by sending an explicit monitoring event for each health-check request.
  * Health checks continue to return successfully with their existing response and logging behavior.

* **Documentation**
  * Added release notes and monitoring documentation for the health-check event.

* **Tests**
  * Added coverage confirming one monitoring event is sent per health-check request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->