### PR TITLE
docs: v2 roadmap, architecture decisions, and advanced-search change

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,345 @@
+# AniDev v2 — Roadmap
+
+> Estado: vivo. Este documento define **qué** se construye y **en qué orden**.
+> El **cómo** de cada feature vive en su change de OpenSpec (`openspec/changes/`),
+> que es la fuente de verdad ejecutable. Este roadmap es la vista de producto;
+> los specs son el contrato.
+
+## Contexto
+
+AniDev v2 es una reconstrucción desde cero de v1 (cerrada, solo referencia) con
+mejor arquitectura y prácticas. La v1 define el **piso de paridad**; la meta es
+igualarla por _slices verticales_ y luego expandir el universo.
+
+**Principio rector:** _priorizar el descubrimiento claro de contenido_ (ver
+`PRODUCT.md`). El orden de fases lo refleja: primero el catálogo y la búsqueda.
+
+## Estado de partida (agosto 2026)
+
+Cimientos sólidos; ~20 % de la superficie de v1.
+
+| Dominio | Estado |
+|---|---|
+| **infra** | Health, error-handling, monitoring (Rustrak), resilience/degradación, cache multicapa (Dragonfly). |
+| **anime** | Read: lista/detalle/`full`/characters/staff. Páginas `/anime/[malId]/[slug]`. |
+| **music** | Read: lista + detalle. Sin player. |
+| **media** | Optimización de imágenes (Sharp), proxy, resolución de assets. Maduro. |
+| **auth** | Login/register/logout/session (Better Auth). |
+| **user** | Read de perfil + writes de identidad (en curso). |
+
+**En vuelo (OpenSpec):** migración provider stack (Turso→Postgres, Upstash→
+Dragonfly, Sentry→Rustrak), `api-response-schema-in-wrapper`, unit folders,
+`standardize-frontend-flow`, user writes.
+
+## Cómo se entrega cada feature
+
+Cada capacidad se implementa como **slice vertical completo**, no por capas
+horizontales:
+
+```
+repository → service → mapper → cache → schema (Zod) → API → isla/página → showcase → tests
+```
+
+Reglas transversales en **todas** las fases:
+
+- **OpenSpec obligatorio**: `SPECIFY → PLAN → TASKS → IMPLEMENT`. Nada se codea sin spec aprobado.
+- **TDD** con Vitest: test que falla antes del fix.
+- **Accesibilidad**: contraste ≥ 4.5:1, navegación por teclado, `focus-visible`, `prefers-reduced-motion`.
+- **Diseño dark-only**, tokens de Tailwind v4, sin colores hardcodeados.
+- **SEO** y performance por defecto (SSR + islas on-demand).
+- **Gate de verificación**: `format → check → check:types → test → build`.
+
+---
+
+## Fases
+
+### Fase 0 — Cerrar cimientos · _en curso_
+
+Desbloquea todo lo demás. No añade features de producto; estabiliza la base.
+
+- [ ] Terminar changes abiertos: provider stack, response-schema wrapper, unit folders, frontend-flow, user writes.
+- [ ] SEO base: sitemaps segmentados (anime, música, géneros, estáticos) + `robots.txt`.
+- [ ] Middleware transversal: rate-limiting, sesión, CSP + headers de seguridad.
+- [ ] Patrón de UI documentado y `/showcase` operativo (living docs).
+
+**Salida:** base estable + patrón de UI repetible antes de escalar.
+
+---
+
+### Fase 1 — Núcleo de descubrimiento 🎯 · _prioridad inmediata_
+
+El corazón del producto. Convierte la v2 en un catálogo explorable de verdad.
+
+- [ ] **Búsqueda avanzada** — filtros: género, tipo, estudio/productora, score (rango), estado, año, rating, temporada, día de emisión + `search_query`; orden configurable; paginación. _(Primer slice: seed en `openspec/changes/advanced-anime-search/`.)_
+- [ ] **Homepage** — héroe + carruseles SSR de contenido relevante.
+- [ ] **Ficha de anime completa** — sinopsis, géneros, personajes, relacionados, banners (RPCs `get_related_anime` / `get_anime_banner`).
+- [ ] **Taxonomía** — páginas por género y por estudio/productora.
+- [ ] **Control parental** — exclusión de ratings adultos embebida en las queries del catálogo (default seguro).
+- [ ] **Historial de búsqueda** — persistido por usuario autenticado.
+
+**Salida:** descubrimiento end-to-end; prerequisito de las recomendaciones IA.
+
+---
+
+### Fase 2 — Identidad y listas · _retención + base de personalización_
+
+- [ ] **Perfil completo** — avatar (subida + recorte vía dominio media/Pinata), preferencias (color de énfasis, control parental), campos extendidos para IA (géneros/estudios favoritos, nivel de fanatismo, frecuencia, formato preferido).
+- [ ] **OAuth** — flujos de proveedores además de email/password.
+- [ ] **Listas de anime** — To Watch / Watching / Completed / Collection con add/remove **optimista + deshacer**.
+
+**Salida:** cuenta con estado propio; datos que alimentan la IA.
+
+---
+
+### Fase 3 — Música y player · _joya de v1, dominio autocontenible_
+
+- [ ] **Player persistente** — `transition:persist` + `client:idle`, store Zustand, superviviente a navegación.
+- [ ] **Playlist** — add/remove con toast + undo, siguiente/anterior, shuffle, repeat, limpiar.
+- [ ] **Cola "Up Next"** reordenable por drag & drop.
+- [ ] **Versión/resolución**, modo audio/video, autoplay al terminar, player arrastrable minimizado.
+- [ ] **Mejora sobre v1**: playlists **persistidas por usuario en BD** (no solo `sessionStorage`).
+- [ ] **Descargas** — openings/endings en audio/video con versión/resolución vía `/api/download`.
+
+**Salida:** paridad + superación del dominio más maduro de v1.
+
+---
+
+### Fase 4 — Recomendaciones IA · _depende de catálogo + perfil_
+
+- [ ] **Motor Gemini** — system prompt de curador experto, function calling (`fetch_recommendations` → `mal_ids`).
+- [ ] **Contextos** — búsqueda actual, viendo, mood, similar-a, estacional, maratón, quick watch.
+- [ ] **Personalización** — perfil de usuario + contexto temporal + estrategia de curación.
+- [ ] **Base + fallback** — Jikan/MAL como base y respaldo cuando Gemini devuelve vacío.
+- [ ] **Utilidades IA** — resumen sin spoilers, keywords, JSON estructurado.
+- [ ] **Mejora**: asistente conversacional en lenguaje natural.
+
+**Salida:** descubrimiento personalizado, el diferenciador de la plataforma.
+
+---
+
+### Fase 5 — Watch / streaming ⚠️ · _bloqueado por datos, no por código_
+
+En v1 `episode.video_url` está vacío: el streaming **no funciona end-to-end**.
+El modelo de datos ya existe (`episode`, `episode_source`, `episode_subtitle`).
+
+- [ ] **Spike de fuente de video** — decisión de legalidad/hosting/integración + backfill de episodios. **Bloqueante de todo lo demás en la fase.**
+- [ ] **Video proxy** — con soporte de range requests.
+- [ ] **Página watch** (`/watch/[slug]`) — navegación de episodios, seguimiento de progreso, selección de calidad y subtítulos.
+- [ ] **Continuar viendo** — reanudación exacta de progreso entre dispositivos.
+
+**Salida:** streaming real. Va tarde a propósito: es un problema de datos/decisión, no de arquitectura.
+
+---
+
+### Fase 6 — Contenido enriquecido
+
+- [ ] **Personajes / artistas / seiyuu** — páginas dedicadas (`/character`, `/artist`, `/voice-actor`) + **backfill** de enlaces voice-actor (v1: ~4.2k de 217k).
+- [ ] **Schedule** — calendario de estrenos/emisiones.
+- [ ] **Colecciones** — `/collection/[slug]` con gestión personal.
+
+**Salida:** fichas ricas y conexiones cruzadas música ↔ artista ↔ seiyuu.
+
+---
+
+### Fase 7 — Expansión del universo · _nuevas capacidades_
+
+- [ ] **Social** — reseñas/comentarios por anime/episodio, ratings/reacciones, perfiles públicos compartibles, seguir usuarios, feed de actividad, foros/clubs por temporada/género.
+- [ ] **Notificaciones** — nuevos episodios de la watch list (push/email), recordatorios de estreno ligados al schedule.
+- [ ] **Gamificación** — logros/insignias (maratones, joyas ocultas), retos de visualización.
+- [ ] **AniDev Wrapped** — estadísticas anuales personalizadas.
+- [ ] **PWA / offline** — música descargada y listas.
+- [ ] **i18n** — unificar UI (inglés) y prompts (español); múltiples idiomas.
+
+**Salida:** comunidad y engagement; la v2 supera a v1 en ambición.
+
+---
+
+---
+
+## Track D — Plataforma de Datos · _paralelo a las fases_
+
+El catálogo de v2 es hoy un **volcado congelado (~2.25M filas, derivado de MAL)**
+sin pipeline vivo: no se refresca, y faltan `studios`/`licensors`, `broadcast`,
+trailers y `episode.video_url`. La ingesta se retoma desde el scraper existente
+([`anime-scraper-v2`](https://github.com/Sebas200702/anime-scraper-v2)), cuya
+arquitectura (cola de tareas en DB, rotación de proxies, multi-fuente, batch
+upsert) es sólida pero falla por **bloqueos** y **tareas perdidas**.
+
+**Fuentes:** Jikan v4 (metadata, characters, staff, episodios-metadata,
+relaciones, **studios/producers/licensors**, **broadcast**, trailers) ·
+AnimeThemes.moe (openings/endings con audio/video reales) · MAL CDN (imágenes) ·
+Kitsu/TVDB (IDs cruzados). Video de episodios: sin fuente legal → muro de Fase 5.
+
+**Principio:** la app **solo lee** Postgres; el pipeline **escribe** Postgres +
+índice de búsqueda. La app nunca llama a las fuentes en request-time (salvo el
+fallback de recomendaciones).
+
+### D.0 — Dos modos de ejecución
+
+El scraper original se diseñó para **llenar una DB vacía** (de ahí su agresividad).
+Cambio de enfoque: ya hay datos con **incongruencias** del pipeline viejo. Se
+separa en dos modos:
+
+- [ ] **Modo A — Backfill + reconciliación** (one-off, entorno **aislado NO-prod**): reconstruye un dataset de catálogo **completo y consistente** hasta el punto de ejecución. Concurrencia alta permitida (no compite con los 8 GB de prod). Al terminar → promoción.
+- [ ] **Modo B — Update incremental** (recurrente, **prod**, ligero): solo añade/actualiza lo **nuevo** (recently-updated de MAL, temporada nueva, entidades faltantes); no barre todo. Baja concurrencia (respeta D8).
+- [ ] **Dashboard de control** (prod): configurar **cadencia** (diaria/semanal) y **alcance** (fuentes/task-types), persistido en DB, disparado por `pg_cron`.
+- [ ] **Promoción A → prod = diff-upsert** (insert nuevos + update cambiados) preservando tablas de usuario/auth/listas y sus FKs, con limpieza dirigida de filas malas. Swap destructivo **descartado**: prod ya tiene datos de usuario que referencian el catálogo por `mal_id`.
+
+### D.1 — Endurecer el scraper (4 capas · aplica a ambos modos)
+
+- [ ] **Fetcher resiliente**: clasificar respuesta (`ok / 429 / blocked / 404 / transient / invalid-body`); retry con backoff+jitter; respetar `Retry-After`; timeouts (`headersTimeout`/`bodyTimeout` + `AbortController`); detectar HTML/challenge antes de `JSON.parse`.
+- [ ] **Proxies**: revivir proxies muertos con re-probe (que el pool no solo encoja); degradar en vez de `throw 'Not enough proxies'`; no penalizar al proxy por un 404 de la fuente.
+- [ ] **Cola crash-safe**: claim con `FOR UPDATE SKIP LOCKED` + lease (`leased_until`) + reaper que re-encola leases expirados; usar `attempts` → `dead_letter` tras N; backoff vía `scheduledAt`; task-type re-encolable para refresh recurrente.
+- [ ] **Rate-limit global**: token bucket por dominio/IP (no por-worker); presupuesto = límite-por-proxy × proxies-sanos. `maxWorkers` **alto en Modo A** (entorno aislado) pero de **unidades en Modo B** (VPS prod 4c/8GB); las 60-80 originales sin entorno propio eran co-causa de los fallos (CPU/RAM además de bloqueos).
+
+### D.2 — Portar a Postgres + integrar
+
+- [ ] Portar de Turso/SQLite a **Postgres** (dialecto Drizzle pg); **anidev-v2 es dueño único del esquema/migraciones**, el scraper no define DDL.
+- [ ] Correr como **servicio separado** en el compose self-hosted, escribiendo a la Postgres compartida.
+- [ ] Scheduling de refresh con **`pg_cron`** (barrido estacional + recently-updated).
+
+### D.3 — Índice y cobertura
+
+- [ ] **Índice de búsqueda (Postgres-native, ver D3)**: el BM25 de ParadeDB se auto-mantiene en cada write (sin sync externo); el pipeline solo mantiene la tabla/vista denormalizada `anime_search` y **genera embeddings pgvector** por anime (synopsis+géneros) como columna a llenar (habilita recs semánticas de Fase 4).
+- [ ] **Métricas de cobertura**: extender `statsReporter` con block-rate, 429-rate, dead-letters y **% de columnas llenas por tabla** (los huecos como dashboard).
+
+### Backfills mapeados a features
+
+| Backfill | Desbloquea |
+|---|---|
+| studios/licensors split + broadcast | Filtros de **estudio** y **día** (Fase 1), Schedule (Fase 6) |
+| voice-actor links (~4.2k de 217k en v1) | Fichas de seiyuu (Fase 6) |
+| episode `video_url` | **Muro de Fase 5** — requiere decisión de fuente, no backfill |
+
+**Dependencia dura:** Fase 1 (búsqueda) necesita D.3 (índice) para ser fresca, y
+D.1 para que los filtros de estudio/día tengan datos.
+
+---
+
+## Frontend (islas · estado · caché)
+
+Base: Astro 6 SSR (`output: 'server'`), `<ClientRouter/>` activo, **cero islas
+aún** (greenfield). El change `standardize-frontend-flow` ya fija zero-JS +
+islas on-demand, one-way y presentational/container. D4+D5 añaden el resto.
+
+**Árbol de estado (usa el nivel más bajo que resuelva):**
+1. Sin JS (`.astro`) → 2. `<form>`+API → 3. `useState` local (una isla) →
+4. **Nano Stores** (estado compartido entre islas) → 5. `transition:persist` +
+nanostore (sobrevive navegación → **player**).
+
+- **Nano Stores = primitivo único** de estado compartido; Zustand solo como
+  escape-hatch justificado (máquina de estados interna del player).
+- **La URL es el estado** en superficies de descubrimiento (búsqueda/filtros):
+  query params = fuente de verdad; isla sincroniza URL↔store y refetch-ea.
+- Persistencia local con `@nanostores/persistent`; playlists por-usuario en DB
+  = hidratación vía API.
+
+**Personalización vs caché (regla en una línea):** _la URL es el estado; el
+shell es anónimo y cacheable; la personalización son islas client-side sobre
+una API por-usuario sin caché._
+
+- **Shell SSR anónimo cacheable** (`public, s-maxage, stale-while-revalidate`).
+- **Control parental = variante de cache-key** (`safe` default / `full` authed
+  opt-in) vía `Vary`/cookie coarse. Nunca cachear por user-id.
+- **Islas personalizadas** (watchlist, continuar viendo, color) → fetch a API
+  `private, no-store` sobre el shell cacheado.
+- Páginas irreduciblemente personales (perfil, listas) → `private, no-store`.
+- Caché en VPS: reverse proxy del PaaS (o Cloudflare delante) + **Dragonfly**
+  (fragmentos/datos) + `Cache-Control` de navegador.
+- **Middleware**: resolución de sesión `pre` debe ser barata (cookie-check), sin
+  golpear DB en páginas cacheables; sesión completa solo en APIs personalizadas.
+
+## Testing y costos
+
+**Pirámide de testing** (corre en **CI/GitHub Actions, no en el VPS** → no toca
+los 8 GB de prod):
+
+- **Unit** (Vitest, TDD) — base, loop rápido del gate. Ya existe.
+- **Integración** — Vitest + **Postgres/ParadeDB real en service container**;
+  rutas API end-to-end + **queries BM25** (no unit-testeables). De-risk de D3.
+- **E2E** — **Playwright** (skill `webapp-testing`), **smoke acotado** de
+  journeys clave (search→ficha, auth, watchlist, player).
+- **a11y** — **axe-core** en Playwright + sobre `/showcase`. No negociable
+  (a11y es principio de producto).
+- Gate por capas: unit rápido local; integración/E2E/a11y = jobs CI separados.
+
+**Modelo de costos** — descubrimiento/música/IA son baratos y acotados al VPS;
+**el video es el único costo sin techo**:
+
+- **IA (Fase 4)**: cache-first (Dragonfly) + **rate-limit duro** en endpoints de
+  IA/búsqueda (abusables). Embeddings ~28k = pocos $ una vez.
+- **Image proxy**: caché inmutable (ya); offload a CDN si escala.
+- **Video (Fase 5)** ⚠️: egress = bomba. **Go/no-go obligatorio con estimación
+  de egress**; storage+CDN externo (p. ej. Cloudflare R2 sin egress — verificar);
+  puede acotarse a set curado o descartarse.
+- Doctrina: **presupuesto de APIs externas** (Gemini/embeddings/Jikan) =
+  cache-first + rate-limit, para que un pico/abuso no dispare costo ni ban.
+
+## Docs (tres audiencias)
+
+Hilo conductor: **generar, no mantener a mano**.
+
+- **UI/componentes → `/showcase`** dinámico API-fed (ya decidido). **Storybook
+  rechazado** (no renderiza `.astro`; `/showcase` con datos reales es superior).
+- **Producto/dev/conceptual → Starlight** (Astro-native, self-host, búsqueda
+  Pagefind offline). **Mintlify rechazado** (SaaS-first, choca con D8). Se
+  despliega como **sitio estático separado** (otro servicio PaaS, ~0 RAM,
+  desacoplado del runtime SSR de la app).
+- **Referencia de API → generada**: Zod 4 (`z.toJSONSchema`) → OpenAPI → render
+  en Starlight (`starlight-openapi`/Scalar); **JSDoc → referencia de código**.
+  Regeneración en **CI** para que no se pudra.
+- **OpenSpec = fuente de verdad interna**; Starlight deriva/enlaza la subserie
+  human-facing, no duplica `AGENTS.md`/`PRODUCT.md`/specs.
+
+## Infra (self-hosted, VPS único)
+
+Todo corre en **un VPS: 4 núcleos / 8 GB RAM / 100 GB SSD** (sin Vercel ni
+Supabase). Servicios ya desplegados: **Postgres** (`database`), **Dragonfly**
+(cache), **Rustrak** (monitoring), **app** (Astro vía `@nurodev/astro-bun`),
+`libredb-studio`. El scraper se añadirá como servicio más.
+
+**La RAM es el recurso escaso** y condiciona toda ampliación:
+
+- Postgres carga **ParadeDB (BM25)** + **pgvector (HNSW/IVFFlat)** además del set
+  de trabajo normal → presupuestar `shared_buffers`/`work_mem`; preferir IVFFlat
+  si HNSW no cabe.
+- **Scraper**: concurrencia real de **unidades**, no las 60-80 del scraper
+  original (co-causa de sus fallos). El rate-limit global lo respeta.
+- **Embeddings**: API externa o batch offline; nada de modelos locales grandes.
+- **Video (Fase 5)**: la media no cabe en el VPS → almacenamiento/CDN **externo**
+  obligatorio si watch entra en scope.
+- Reconciliar `@astrojs/vercel` (residual en deps) → adaptador Bun/Node.
+
+## Decisiones de arquitectura (log)
+
+Registro vivo de decisiones transversales. `OPEN` = pendiente de cerrar.
+
+| # | Decisión | Estado |
+|---|---|---|
+| D1 | Scraper en **dos modos/entornos**: (A) **backfill+reconciliación** one-off en entorno aislado NO-prod (agresivo permitido; reconstruye dataset consistente) → **promoción a prod**; (B) **update incremental** en prod, ligero, **configurable desde dashboard** (cadencia+alcance) vía `pg_cron`. Servicio separado; v2 dueño del esquema; sin paquete compartido aún. **Promoción = diff-upsert** (prod tiene datos de usuario → swap destructivo descartado) | ✅ decidido |
+| D2 | Cola de ingesta = **Postgres-nativo** (`FOR UPDATE SKIP LOCKED` + `pg_cron`); rate-bucket en memoria (single-instance) | ✅ decidido |
+| D3 | Búsqueda = **Postgres-only por etapas**: `pg_trgm`/tsvector (MVP) → **ParadeDB `pg_search`** BM25 (relevancia/typo/facetas, Drizzle-native, índice auto-mantenido) → **pgvector** (recs semánticas + híbrido RRF, Bun-native). Un solo datastore, sin sync externo. **Confirmado: Postgres self-hosted en VPS → las 3 etapas disponibles** (ver D8 para presupuesto de RAM de los índices) | ✅ decidido |
+| D4 | Estado entre islas (ver §Frontend): árbol de 5 niveles; **Nano Stores** primitivo único (Zustand escape-hatch); **URL = estado** en descubrimiento; `transition:persist` para el player | ✅ decidido |
+| D5 | Personalización vs caché (ver §Frontend): **shell anónimo cacheable + islas personalizadas** sobre API `no-store`; control parental = variante de cache-key (`safe`/`full`), nunca por user-id; middleware `pre` barato | ✅ decidido |
+| D6 | Docs (ver §Docs): **`/showcase`** (UI, Storybook rechazado) + **Starlight** sitio estático separado (Mintlify rechazado, SaaS) + **referencia API generada** desde Zod→OpenAPI y JSDoc, regenerada en CI | ✅ decidido |
+| D7 | Testing y costos (ver §Testing y costos): pirámide unit→integración(ParadeDB en CI)→E2E(Playwright)→**a11y axe**, toda en CI (no en VPS); **presupuesto de APIs externas** cache-first+rate-limit; **Fase 5 video = go/no-go con estimación de egress** | ✅ decidido |
+| D8 | **Presupuesto de recursos** (ver §Infra): todo en 1 VPS 4c/8GB/100GB. RAM = cuello. BM25/HNSW presupuestados (`shared_buffers`/`work_mem`; IVFFlat si HNSW no cabe); scraper de baja concurrencia (unidades); embeddings vía API/batch (no modelo local grande); media de video **fuera** del VPS | ✅ restricción fijada |
+
+---
+
+## Riesgos y dependencias clave
+
+- **Fase 5 (video)** depende de una decisión de fuente/legalidad que no es
+  técnica; abordarla como spike aislado antes de comprometer UI.
+- **Fase 4 (IA)** depende de que Fase 1 (catálogo) y Fase 2 (perfil) estén
+  completas para tener señal de personalización.
+- **Backfills de datos** (voice-actor, episodios) son trabajo de datos paralelo
+  al de features; conviene planearlos como tareas propias.
+
+## Convenciones de este documento
+
+- Marcar `[x]` una capacidad **solo** cuando su change de OpenSpec esté archivado.
+- Un ítem del roadmap puede abarcar varios changes; enlazar el primer change
+  seed cuando exista.
+- El orden entre fases es firme; dentro de una fase puede ajustarse por
+  dependencias.

--- a/openspec/changes/advanced-anime-search/design.md
+++ b/openspec/changes/advanced-anime-search/design.md
@@ -1,0 +1,122 @@
+## Context
+
+See `proposal.md` — Why, and `ROADMAP.md` decisions D3 (Postgres-only staged
+search), D5 (personalization vs cache), D1/Track D (data backfill gates
+studio/day). Today:
+
+- `GET /api/anime` → `animeListService.getAnimeList` → `animeRepository` query,
+  read-through cached via `animeListCache.key(filters)`.
+- Request validated by `animeFiltersParamsSchema`; `mapAnimeFilters` normalizes
+  scalars → arrays for `genre/status/rating/type`, passes `year/query/page/limit`.
+- Free-text `query` is a naive `ILIKE` (unindexed).
+- `anime` has `season`, `score` (real), `rating`; facet joins exist
+  (`anime_genre`, `anime_theme`, `anime_demographic`, `anime_producer`).
+- No `broadcast_*` columns; `producer` has no studio/licensor split → **studio and
+  day filters are not data-backed** and are out of scope here.
+- The sibling change `api-response-schema-in-wrapper` moves routes to
+  `withZodValidation(...)(withErrorHandling(handler, { responseSchema }))`; this
+  change targets that composition.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Add `season`, `scoreMin`, `scoreMax`, `sort`, `order` to the list/search query,
+  backward-compatible with existing params and cache behavior.
+- Replace `ILIKE` free-text with an indexed `pg_trgm` + `tsvector` match (Stage 1).
+- Apply a parental-control floor as a coarse `safe`/`full` **cache-key variant**.
+- Persist per-user search history (record on search; authed read + clear).
+- Keep the query layer swappable so Stage 2 (ParadeDB BM25) needs no API change.
+
+**Non-Goals**
+
+- Studio filter, broadcast-day filter, facet counts — blocked on Track D backfill.
+- ParadeDB/BM25 relevance and pgvector semantic search — Stage 2/3, separate.
+- Any frontend page/island (`/showcase` demo + search UI are follow-ups).
+- Per-user response caching (personalization stays client-side per D5).
+
+## Decisions
+
+### 1. Query approach — Stage 1 stock Postgres
+
+- **Free-text:** GIN `pg_trgm` index on `anime.title` (+ `anime_title_synonym`)
+  and/or a `tsvector` expression; rank with `similarity()` / `ts_rank`. No new
+  extension beyond `pg_trgm` (`CREATE EXTENSION IF NOT EXISTS pg_trgm`).
+- **Filters:** `season` = equality on `anime.season`; `scoreMin/scoreMax` = range
+  on `anime.score` (nulls excluded when a bound is set). Existing array facets
+  (`genre/status/rating/type`) unchanged.
+- **Sort:** `sort ∈ { score, year, title, relevance }`, `order ∈ { asc, desc }`,
+  applied via a **whitelist** (never interpolate raw input into SQL). `relevance`
+  only valid when `query` is present; default sort stays as today when unset.
+
+### 2. Parental-control floor (D5)
+
+- Compute a coarse `parentalVariant: 'safe' | 'full'`. `safe` = default for
+  anonymous and non-opted-in users; excludes a configured `ADULT_RATINGS` set on
+  `anime.rating`. `full` = authenticated user whose profile preference opts in.
+- The variant is a **cache-key dimension** (`animeListCache.key` includes it), so
+  there are at most two cached variants per filter set — never keyed by user id.
+
+### 3. Search history — anime-domain unit
+
+- New unit `@anime/repositories/search-history` + `@anime/services/search-history`
+  (kind files `repository.ts` / `service.ts` + `types.ts`, per unit-folder rule).
+- New table `search_history` (`id`, `user_id` text, `query` text, `filters`
+  jsonb, `created_at`). FK-light: `user_id` matches the auth user id string used
+  elsewhere (see user-domain `profile.id` convention; do not invent a migration
+  beyond this table).
+- **Record** best-effort after a successful authed search (failure to record
+  MUST NOT fail the search). **Read** returns the caller's recent searches;
+  **clear** deletes the caller's rows. All authed, owner-only, `private, no-store`.
+
+### 4. HTTP surface
+
+- `GET /api/anime` — unchanged route, extended query params; response schema
+  validated by the wrapper. Records history when a session is present.
+- `GET /api/anime/search-history` — authed; returns recent searches.
+- `DELETE /api/anime/search-history` — authed; clears caller's history.
+
+### 5. Layering (same vertical slice as existing reads)
+
+```text
+Route (Zod params + wrapper responseSchema)
+  → animeListService.getAnimeList(filters, actor)
+    → parental variant → repository (indexed text + filters + whitelist sort)
+    → map cards → cache by key(filters + variant)
+  → (session) searchHistoryService.record(actor, query, filters)  // best-effort
+```
+
+### 6. Validation schemas
+
+- Extend `animeFiltersParamsSchema`: `season?`, `scoreMin?`/`scoreMax?`
+  (`z.coerce.number().min(0).max(10)`, `scoreMin ≤ scoreMax`), `sort?`/`order?`
+  as enums. Extend `animeFiltersSchema` (normalized) accordingly.
+- `searchHistoryQuerySchema` (limit) and response schema for history entries.
+
+### 7. Cache
+
+- Extend `animeListCache.key` to fold in `season/scoreMin/scoreMax/sort/order` and
+  the `parentalVariant`. Keep key ordering stable for hit rate.
+
+## Risks / Trade-offs
+
+- **[Text index cost on the VPS (D8)]** GIN `pg_trgm` on title/synonyms adds
+  index memory; scope indexes to the searched columns only, verify `EXPLAIN` on
+  the live dataset.
+- **[Sort injection]** mitigated by strict whitelist mapping, no raw interpolation.
+- **[History write coupling]** record is best-effort and out of the response path;
+  never blocks or fails the search.
+- **[Stage-1 relevance is modest]** `pg_trgm`/`ts_rank` < BM25; acceptable for MVP,
+  and the swappable query layer keeps Stage 2 cheap.
+
+## Migration Plan
+
+- Add `pg_trgm` extension + GIN index migration and the `search_history` table via
+  Drizzle (`db:generate` / `db:migrate`); anidev-v2 owns the schema (D1).
+- TDD per task group; ship on `feat/advanced-anime-search`; pass the gate
+  (`format → check → check:types → test → build`); PR, no release bump until asked.
+
+## Open Questions
+
+- Exact `ADULT_RATINGS` set + where the opt-in preference is read on `profile`
+  (confirm against live schema during task 4, mirroring user-domain conventions).

--- a/openspec/changes/advanced-anime-search/proposal.md
+++ b/openspec/changes/advanced-anime-search/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+Discovery is the core of AniDev (`PRODUCT.md`: _priorizar el descubrimiento_), but
+`GET /api/anime` only supports a thin filter set (`genre`, `status`, `rating`,
+`year`, `type`, free-text `query`) with fixed ordering and a naive `ILIKE` text
+match. v1's advanced search added **season, score range, and configurable sort**,
+applied a **parental-control floor**, and persisted a **search history** per user.
+Without these, the v2 catalog is not explorable to parity, and later work (AI
+recommendations, Fase 4) has no rich query surface to build on.
+
+Per the architecture decision log (`ROADMAP.md` D3), search stays **Postgres-only,
+staged**: this change is **Stage 1** — stock Postgres (`pg_trgm` + `tsvector` +
+`GROUP BY`), no ParadeDB/BM25 yet. The query layer is structured so BM25 (Stage 2)
+and pgvector (Stage 3) can be swapped in later **without an API change**.
+
+## What Changes
+
+- Improve **free-text relevance**: replace `ILIKE '%q%'` with a `pg_trgm` GIN +
+  `tsvector` match over title/synonyms (indexed, typo-tolerant-ish). Stage 1 only.
+- Add **data-backed filters** that the current dataset supports: **`season`** and
+  **score range** (`scoreMin`/`scoreMax`).
+- Add **configurable sort** (`sort` field + `order` direction) over a whitelist.
+- Add a **parental-control floor**: adult ratings excluded by default; included
+  only for an authenticated user who opted in. Modeled as a **coarse cache-key
+  variant** (`safe` / `full`), never per user id (`ROADMAP.md` D5).
+- Add **search history**: persist an authenticated user's executed searches;
+  expose read + clear. Anonymous searches are not persisted (`private, no-store`).
+- Wire everything through the existing pipeline (request schema → filters mapper →
+  repository query → cache key) using the standard wrapper composition
+  (`withZodValidation(...)(withErrorHandling(handler, { responseSchema }))`).
+
+**Explicitly deferred (blocked on Track D data backfill, `ROADMAP.md`):**
+
+- **Studio filter** — current data only has generic `producer` rows (no
+  studio/licensor split). A true studio filter waits on the Track D backfill.
+- **Broadcast-day filter** — no `broadcast_*` columns are populated yet; deferred
+  to the same backfill.
+- **Facet counts** ("Action (1240)") — a fast-follow once the filter surface lands.
+- **BM25 / semantic ranking** — Stage 2/3, separate changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `anime/advanced-search`: Extended, validated multi-filter search over the anime
+  catalog (season, score range, configurable sort, improved free-text) with a
+  parental-control cache-variant floor and per-user search history, on Stage-1
+  stock Postgres.
+
+### Modified Capabilities
+
+- (none committed under `openspec/specs/` for the anime domain yet)
+
+## Impact
+
+- **Code:** `src/domains/anime/` (schemas, `mappers/anime-filters`, repositories,
+  services, cache keys), `src/pages/api/anime/index.ts`; a user-scoped search
+  history unit in the **anime** domain + its authed route(s).
+- **API:** `GET /api/anime` gains `season`, `scoreMin`, `scoreMax`, `sort`,
+  `order`; existing params unchanged and backward-compatible. New authed
+  search-history read/clear route(s).
+- **Auth:** parental `full` variant and search history require a session; the
+  anonymous default is the safe catalog with no history.
+- **DB:** existing `anime` columns (`season`, `score`, `rating`) + a new
+  `search_history` table and search **indexes** (`pg_trgm` GIN on title/synonyms,
+  `tsvector`). Migrations owned by anidev-v2 (D1).
+- **Cache:** filter cache keys extend with the new dimensions **and the parental
+  `safe`/`full` variant**.
+- **Deps:** none (stock Postgres extensions `pg_trgm`; `tsvector` is built-in).

--- a/openspec/changes/advanced-anime-search/specs/anime/advanced-search/spec.md
+++ b/openspec/changes/advanced-anime-search/specs/anime/advanced-search/spec.md
@@ -1,0 +1,122 @@
+## Purpose
+
+Extends anime catalog search with data-backed filters (`season`, score range),
+configurable sort, indexed free-text relevance, a parental-control floor modeled
+as a coarse cache-key variant, and per-user search history — all on Stage-1 stock
+Postgres, with the query layer swappable for later BM25/vector stages.
+
+## ADDED Requirements
+
+### Requirement: Extended, data-backed catalog filters
+
+The system MUST let `GET /api/anime` filter by `season` (equality on the anime
+season) and by a score range (`scoreMin` / `scoreMax`, each 0–10). Existing
+filters (`genre`, `status`, `rating`, `type`, `year`, `query`, `page`, `limit`)
+MUST keep working unchanged. Invalid values (e.g. `scoreMin > scoreMax`) MUST be
+rejected at the request boundary.
+
+#### Scenario: Filter by season and score range
+
+- **WHEN** a client requests `GET /api/anime?season=spring&scoreMin=7&scoreMax=9`
+- **THEN** the response contains only anime whose season matches and whose score
+  is within `[7, 9]`, in the standard paginated envelope
+
+#### Scenario: Invalid score range
+
+- **WHEN** a client requests a score range where `scoreMin > scoreMax`
+- **THEN** the system responds `400 VALIDATION_ERROR` and does not run a query
+
+#### Scenario: Backward compatibility
+
+- **WHEN** a client requests `GET /api/anime` with only the pre-existing params
+- **THEN** the response shape and results are unchanged from before this change
+
+### Requirement: Configurable sort over a whitelist
+
+The system MUST accept `sort` (one of a fixed whitelist, e.g. `score`, `year`,
+`title`, `relevance`) and `order` (`asc` / `desc`). Values outside the whitelist
+MUST be rejected. `relevance` MUST be valid only when a `query` term is present.
+Raw sort input MUST NOT be interpolated into SQL.
+
+#### Scenario: Sort by score descending
+
+- **WHEN** a client requests `GET /api/anime?sort=score&order=desc`
+- **THEN** results are ordered by score, highest first
+
+#### Scenario: Relevance sort without a query
+
+- **WHEN** a client requests `sort=relevance` with no `query`
+- **THEN** the system responds `400 VALIDATION_ERROR`
+
+#### Scenario: Unknown sort field
+
+- **WHEN** a client requests a `sort` value outside the whitelist
+- **THEN** the system responds `400 VALIDATION_ERROR`
+
+### Requirement: Indexed free-text relevance (Stage 1)
+
+The system MUST match the free-text `query` against anime titles (and synonyms)
+using an indexed `pg_trgm` / `tsvector` match instead of an unindexed `ILIKE`
+scan. The API contract for `query` MUST remain unchanged so later ranking stages
+(BM25/vector) can replace the implementation without an API change.
+
+#### Scenario: Free-text query returns ranked matches
+
+- **WHEN** a client searches `GET /api/anime?query=cowboy`
+- **THEN** matching anime are returned ranked by text relevance, using the index
+
+### Requirement: Parental-control floor as a cache variant
+
+The system MUST exclude adult-rated anime by default (the `safe` variant) for
+anonymous callers and authenticated users who have not opted in. Adult-rated
+anime MUST be included only for an authenticated user whose preference opts in
+(the `full` variant). The parental variant MUST be a coarse cache-key dimension
+(`safe` / `full`) and MUST NOT be keyed by user id.
+
+#### Scenario: Anonymous caller gets the safe catalog
+
+- **WHEN** an anonymous client searches the catalog
+- **THEN** adult-rated anime are excluded from results
+
+#### Scenario: Opted-in authenticated user sees full catalog
+
+- **WHEN** an authenticated user who opted in searches the catalog
+- **THEN** adult-rated anime are included
+
+#### Scenario: Cache is not per-user
+
+- **WHEN** two different users produce the same filters and parental variant
+- **THEN** they resolve to the same cache entry (at most two variants per filter set)
+
+### Requirement: Per-user search history
+
+The system MUST record an authenticated user's executed searches (query + filters)
+on a best-effort basis, and MUST expose authenticated, owner-only endpoints to
+read recent searches and to clear them. Anonymous searches MUST NOT be persisted.
+A failure to record history MUST NOT fail the search request. History responses
+MUST NOT be cached (`private, no-store`).
+
+#### Scenario: Search is recorded for an authenticated user
+
+- **WHEN** an authenticated user runs a search
+- **THEN** the search (query + filters) is stored against their user id
+
+#### Scenario: Anonymous search is not recorded
+
+- **WHEN** an anonymous client runs a search
+- **THEN** no history row is written
+
+#### Scenario: History write failure does not break search
+
+- **WHEN** recording the history row fails
+- **THEN** the search still returns its results successfully
+
+#### Scenario: Owner reads and clears history
+
+- **WHEN** an authenticated user calls read, then clear, on their search history
+- **THEN** read returns their recent searches and clear deletes only their rows
+
+#### Scenario: Unauthenticated history access
+
+- **WHEN** an anonymous client calls the search-history read or clear endpoint
+- **THEN** the system responds with an authentication error and touches no data

--- a/openspec/changes/advanced-anime-search/tasks.md
+++ b/openspec/changes/advanced-anime-search/tasks.md
@@ -1,0 +1,43 @@
+## 1. Schemas and types
+
+- [ ] 1.1 Extend `animeFiltersParamsSchema` with `season?`, `scoreMin?`, `scoreMax?` (coerced 0–10, `scoreMin ≤ scoreMax` refinement), `sort?` / `order?` enums; extend normalized `animeFiltersSchema` to match
+- [ ] 1.2 Add `searchHistoryQuerySchema` (limit) + search-history entry/response schemas; export all from `@anime/schemas`
+- [ ] 1.3 Add `AnimeFilters` type fields + `ParentalVariant` and search-history types under the anime domain `types/`
+
+## 2. Filters mapper (TDD)
+
+- [ ] 2.1 Write failing tests for `mapAnimeFilters` covering `season`, score range, and `sort/order` defaults + passthrough
+- [ ] 2.2 Implement the new fields in `mappers/anime-filters/mapper.ts` (keep cache-key stability)
+
+## 3. Repository query (TDD)
+
+- [ ] 3.1 Write failing tests (Vitest + Postgres service container) for: `season` equality, score range (nulls excluded when bounded), whitelist `sort`/`order`, and `pg_trgm`/`tsvector` text match ranking
+- [ ] 3.2 Add migration: `CREATE EXTENSION IF NOT EXISTS pg_trgm`, GIN trigram index on `anime.title` (+ `anime_title_synonym`), `tsvector` expression/index as needed
+- [ ] 3.3 Implement the extended query in the anime repository: indexed text match replacing `ILIKE`, new filters, and strict whitelist sort (no raw interpolation)
+
+## 4. Parental floor + service (TDD)
+
+- [ ] 4.1 Write failing tests for `parentalVariant` resolution (anonymous → `safe`; authed opt-in → `full`) and that `safe` excludes `ADULT_RATINGS`
+- [ ] 4.2 Confirm `ADULT_RATINGS` set + opt-in preference location against live `profile` schema (mirror user-domain conventions; no drive-by migration)
+- [ ] 4.3 Implement variant resolution in `animeListService.getAnimeList` and fold the variant into `animeListCache.key`
+- [ ] 4.4 Write failing test proving cache produces at most `safe`/`full` variants per filter set (never keyed by user id)
+
+## 5. Search history unit (TDD)
+
+- [ ] 5.1 Add migration for `search_history` (`id`, `user_id` text, `query` text, `filters` jsonb, `created_at`)
+- [ ] 5.2 Write failing tests for `searchHistoryRepository` (record / list-by-user / clear-by-user, `dbError` on failure)
+- [ ] 5.3 Implement repository + `searchHistoryService` (owner-only) as anime-domain unit folders
+- [ ] 5.4 Write failing test proving `record` is best-effort: a history write failure does NOT fail the search
+
+## 6. API routes (TDD)
+
+- [ ] 6.1 Write failing route tests for extended `GET /api/anime` (new params validate; existing behavior unchanged; parental variant applied; history recorded when session present)
+- [ ] 6.2 Migrate/keep `GET /api/anime` on `withZodValidation(...)(withErrorHandling(handler, { responseSchema }))`; wire new filters + best-effort history record
+- [ ] 6.3 Write failing tests for `GET`/`DELETE /api/anime/search-history` (401 anon, 200 owner list, 200 clear)
+- [ ] 6.4 Implement authed search-history read + clear routes (`private, no-store`)
+
+## 7. Verification
+
+- [ ] 7.1 Run `bun run format`, `bun run check`, `bun run check:types`, `bun run test`, `bun run build`
+- [ ] 7.2 `EXPLAIN` the text + filter query on the live dataset; confirm index usage and acceptable plan on the VPS
+- [ ] 7.3 Mark tasks complete; Conventional Commits per task group; release only when the user requests a PR/release per AGENTS.md


### PR DESCRIPTION
## Summary

Planning deliverable from the roadmap review session. Docs/spec only — no runtime changes, no release bump.

- **`ROADMAP.md`** (new): phased roadmap (Fases 0–7) + **Track D — Data Platform** (harden the existing scraper into a two-mode pipeline: isolated backfill+reconciliation → diff-upsert to prod, plus a light dashboard-configurable incremental update) + cross-cutting sections (§Frontend, §Docs, §Infra, §Testing y costos).
- **Architecture decision log (D1–D8)** closed during the review:
  - **D1** scraper two-mode/two-env + diff-upsert promotion
  - **D2** Postgres-native ingestion queue (`SKIP LOCKED` + `pg_cron`)
  - **D3** Postgres-only staged search (`pg_trgm`/tsvector → ParadeDB BM25 → pgvector)
  - **D4** island state doctrine (Nano Stores, URL = state, `transition:persist`)
  - **D5** personalization vs cache (anonymous cacheable shell + personalized islands; parental control as `safe`/`full` cache variant)
  - **D6** docs (`/showcase` + Starlight, API docs generated from Zod/JSDoc)
  - **D7** testing pyramid in CI + external-API cost budget; Fase 5 video = go/no-go on egress
  - **D8** single-VPS (4c/8GB/100GB) resource budget
- **`openspec/changes/advanced-anime-search/`** (new): OpenSpec change (proposal/design/tasks/spec delta) for the first Fase 1 slice — Stage-1 Postgres advanced search (season, score range, whitelist sort, indexed free-text), parental floor as a cache variant, per-user search history. Studio/broadcast-day filters deferred to the Track D backfill; query layer kept swappable for later BM25/vector stages.

## Notes

- All content is documentation + an OpenSpec proposal awaiting the `openspec-apply-change` flow; nothing is implemented yet.
- Reconciled against real repo state (existing domains, in-flight `api-response-schema-in-wrapper`) and the deployed self-hosted infra.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive roadmap for AniDev v2, outlining planned delivery phases, quality standards, architecture, data strategy, testing, infrastructure, and maintenance practices.
  - Documented the proposed first stage of advanced anime search, including season and score filters, relevance-based text search, sorting, parental-content variants, and personalized search history.
  - Added implementation guidance covering validation, caching, authentication, database requirements, testing, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->