### PR TITLE
docs: update ROADMAP with advanced search scope, transactional promotion, and testing/caching policies; initialize design and specs for advanced anime search

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Dragonfly, Sentry→Rustrak), `api-response-schema-in-wrapper`, unit folders,
 Cada capacidad se implementa como **slice vertical completo**, no por capas
 horizontales:
 
-```
+```text
 repository → service → mapper → cache → schema (Zod) → API → isla/página → showcase → tests
 ```
 
@@ -70,7 +70,7 @@ Desbloquea todo lo demás. No añade features de producto; estabiliza la base.
 
 El corazón del producto. Convierte la v2 en un catálogo explorable de verdad.
 
-- [ ] **Búsqueda avanzada** — filtros: género, tipo, estudio/productora, score (rango), estado, año, rating, temporada, día de emisión + `search_query`; orden configurable; paginación. _(Primer slice: seed en `openspec/changes/advanced-anime-search/`.)_
+- [ ] **Búsqueda avanzada** — filtros: género, tipo, score (rango), estado, año, rating, temporada + `search_query`; orden configurable; paginación. **Estudio/productora y día de emisión quedan diferidos** hasta el backfill del Track D (fuera del Stage 1). _(Primer slice: seed en `openspec/changes/advanced-anime-search/`.)_
 - [ ] **Homepage** — héroe + carruseles SSR de contenido relevante.
 - [ ] **Ficha de anime completa** — sinopsis, géneros, personajes, relacionados, banners (RPCs `get_related_anime` / `get_anime_banner`).
 - [ ] **Taxonomía** — páginas por género y por estudio/productora.
@@ -183,14 +183,14 @@ separa en dos modos:
 - [ ] **Modo A — Backfill + reconciliación** (one-off, entorno **aislado NO-prod**): reconstruye un dataset de catálogo **completo y consistente** hasta el punto de ejecución. Concurrencia alta permitida (no compite con los 8 GB de prod). Al terminar → promoción.
 - [ ] **Modo B — Update incremental** (recurrente, **prod**, ligero): solo añade/actualiza lo **nuevo** (recently-updated de MAL, temporada nueva, entidades faltantes); no barre todo. Baja concurrencia (respeta D8).
 - [ ] **Dashboard de control** (prod): configurar **cadencia** (diaria/semanal) y **alcance** (fuentes/task-types), persistido en DB, disparado por `pg_cron`.
-- [ ] **Promoción A → prod = diff-upsert** (insert nuevos + update cambiados) preservando tablas de usuario/auth/listas y sus FKs, con limpieza dirigida de filas malas. Swap destructivo **descartado**: prod ya tiene datos de usuario que referencian el catálogo por `mal_id`.
+- [ ] **Promoción A → prod = diff-upsert** por clave de identidad (`mal_id`): insert nuevos + update cambiados, en **transacción atómica** con orden FK-safe (padres→hijos), **validación referencial previa** y **rollback** ante fallo. Política explícita de filas obsoletas: solo se eliminan huérfanas **no referenciadas por datos de usuario**. Preserva tablas de usuario/auth/listas y sus FKs. Swap destructivo **descartado**: prod ya tiene datos de usuario que referencian el catálogo por `mal_id`. _(D1 mantiene el mecanismo decidido — diff-upsert; este protocolo es su detalle de implementación en Track D.)_
 
 ### D.1 — Endurecer el scraper (4 capas · aplica a ambos modos)
 
 - [ ] **Fetcher resiliente**: clasificar respuesta (`ok / 429 / blocked / 404 / transient / invalid-body`); retry con backoff+jitter; respetar `Retry-After`; timeouts (`headersTimeout`/`bodyTimeout` + `AbortController`); detectar HTML/challenge antes de `JSON.parse`.
 - [ ] **Proxies**: revivir proxies muertos con re-probe (que el pool no solo encoja); degradar en vez de `throw 'Not enough proxies'`; no penalizar al proxy por un 404 de la fuente.
 - [ ] **Cola crash-safe**: claim con `FOR UPDATE SKIP LOCKED` + lease (`leased_until`) + reaper que re-encola leases expirados; usar `attempts` → `dead_letter` tras N; backoff vía `scheduledAt`; task-type re-encolable para refresh recurrente.
-- [ ] **Rate-limit global**: token bucket por dominio/IP (no por-worker); presupuesto = límite-por-proxy × proxies-sanos. `maxWorkers` **alto en Modo A** (entorno aislado) pero de **unidades en Modo B** (VPS prod 4c/8GB); las 60-80 originales sin entorno propio eran co-causa de los fallos (CPU/RAM además de bloqueos).
+- [ ] **Rate-limit global**: token bucket por dominio/IP (no por-worker). **Ámbito por fuente primero**: usar por defecto el **menor límite efectivo de la fuente** (incl. los de Jikan/MAL que disparan 429); multiplicar por proxies-sanos **solo si la fuente confirma que el límite es por-IP/proxy** (no si es global o por-API-key). `maxWorkers` **alto en Modo A** (entorno aislado) pero de **unidades en Modo B** (VPS prod 4c/8GB); las 60-80 originales sin entorno propio eran co-causa de los fallos (CPU/RAM además de bloqueos).
 
 ### D.2 — Portar a Postgres + integrar
 
@@ -240,7 +240,9 @@ una API por-usuario sin caché._
 
 - **Shell SSR anónimo cacheable** (`public, s-maxage, stale-while-revalidate`).
 - **Control parental = variante de cache-key** (`safe` default / `full` authed
-  opt-in) vía `Vary`/cookie coarse. Nunca cachear por user-id.
+  opt-in) vía `Vary`/cookie coarse. Nunca cachear por user-id. Anónimo siempre
+  `safe`; si la capa de caché **no garantiza aislamiento de variantes**, la
+  variante `full` no se comparte (`private, no-store`).
 - **Islas personalizadas** (watchlist, continuar viendo, color) → fetch a API
   `private, no-store` sobre el shell cacheado.
 - Páginas irreduciblemente personales (perfil, listas) → `private, no-store`.
@@ -255,8 +257,10 @@ una API por-usuario sin caché._
 los 8 GB de prod):
 
 - **Unit** (Vitest, TDD) — base, loop rápido del gate. Ya existe.
-- **Integración** — Vitest + **Postgres/ParadeDB real en service container**;
-  rutas API end-to-end + **queries BM25** (no unit-testeables). De-risk de D3.
+- **Integración** — Vitest + **Postgres/ParadeDB real en service container**
+  (imagen y versión **pinneadas**, bootstrap de extensiones + **healthcheck que
+  falla si `pg_search`/`vector` no están disponibles**); rutas API end-to-end +
+  **queries BM25** (no unit-testeables). De-risk de D3.
 - **E2E** — **Playwright** (skill `webapp-testing`), **smoke acotado** de
   journeys clave (search→ficha, auth, watchlist, player).
 - **a11y** — **axe-core** en Playwright + sobre `/showcase`. No negociable

--- a/openspec/changes/advanced-anime-search/design.md
+++ b/openspec/changes/advanced-anime-search/design.md
@@ -13,9 +13,12 @@ studio/day). Today:
   (`anime_genre`, `anime_theme`, `anime_demographic`, `anime_producer`).
 - No `broadcast_*` columns; `producer` has no studio/licensor split → **studio and
   day filters are not data-backed** and are out of scope here.
-- The sibling change `api-response-schema-in-wrapper` moves routes to
-  `withZodValidation(...)(withErrorHandling(handler, { responseSchema }))`; this
-  change targets that composition.
+- **Prerequisite:** the sibling change `api-response-schema-in-wrapper` moves
+  routes to `withZodValidation(...)(withErrorHandling(handler, { responseSchema }))`;
+  this change **targets that composition and must land after it** (ordered in
+  tasks). Adopting the wrapper **removes** the route's inline
+  `animeListResponseSchema.parse` and manual success-path `jsonResponse` — the
+  wrapper validates and serializes the response.
 
 ## Goals / Non-Goals
 
@@ -40,20 +43,33 @@ studio/day). Today:
 ### 1. Query approach — Stage 1 stock Postgres
 
 - **Free-text:** GIN `pg_trgm` index on `anime.title` (+ `anime_title_synonym`)
-  and/or a `tsvector` expression; rank with `similarity()` / `ts_rank`. No new
-  extension beyond `pg_trgm` (`CREATE EXTENSION IF NOT EXISTS pg_trgm`).
+  and/or a `tsvector` expression. The WHERE **match predicate MUST be
+  index-backed** — `title % :q` (pg_trgm) or `tsvector @@ plainto_tsquery(:q)` —
+  applied **before** ranking with `similarity()` / `ts_rank` (ranking alone does
+  not use the index). No new extension beyond `pg_trgm`
+  (`CREATE EXTENSION IF NOT EXISTS pg_trgm`).
 - **Filters:** `season` = equality on `anime.season`; `scoreMin/scoreMax` = range
   on `anime.score` (nulls excluded when a bound is set). Existing array facets
   (`genre/status/rating/type`) unchanged.
-- **Sort:** `sort ∈ { score, year, title, relevance }`, `order ∈ { asc, desc }`,
-  applied via a **whitelist** (never interpolate raw input into SQL). `relevance`
-  only valid when `query` is present; default sort stays as today when unset.
+- **Sort:** `sort ∈ { score, year, title, relevance }` (default `score`),
+  `order ∈ { asc, desc }` (default `desc`), applied via a **whitelist** (never
+  interpolate raw input into SQL). Every sort **appends `anime.malId` as a unique
+  secondary key** so `LIMIT/OFFSET` pages are deterministic across adjacent
+  pages. `order` without `sort` uses the default sort. `relevance` is valid only
+  when `query` is present and **non-empty after trimming whitespace**.
 
 ### 2. Parental-control floor (D5)
 
-- Compute a coarse `parentalVariant: 'safe' | 'full'`. `safe` = default for
-  anonymous and non-opted-in users; excludes a configured `ADULT_RATINGS` set on
-  `anime.rating`. `full` = authenticated user whose profile preference opts in.
+- Compute a coarse `parentalVariant: 'safe' | 'full'`. **Fail-closed:** `safe` is
+  the default and is used whenever the preference or the `ADULT_RATINGS` config
+  cannot be read; it excludes a configured `ADULT_RATINGS` set on `anime.rating`.
+  `full` requires an authenticated user who explicitly opted in — **never select
+  `full` by default**.
+- **The opt-in preference column does not exist on `profile` yet** (verified
+  against the live schema — no parental/adult field). Until it is added, `full`
+  is unreachable and every caller gets `safe`: this change ships the variant
+  **plumbing** ready, and adding the preference field is a **prerequisite change**
+  to enable `full`.
 - The variant is a **cache-key dimension** (`animeListCache.key` includes it), so
   there are at most two cached variants per filter set — never keyed by user id.
 
@@ -62,9 +78,12 @@ studio/day). Today:
 - New unit `@anime/repositories/search-history` + `@anime/services/search-history`
   (kind files `repository.ts` / `service.ts` + `types.ts`, per unit-folder rule).
 - New table `search_history` (`id`, `user_id` text, `query` text, `filters`
-  jsonb, `created_at`). FK-light: `user_id` matches the auth user id string used
-  elsewhere (see user-domain `profile.id` convention; do not invent a migration
-  beyond this table).
+  jsonb, `created_at`) with an **index on (`user_id`, `created_at` DESC)** to
+  serve recent-listing and clear. FK-light: `user_id` matches the auth user id
+  string used elsewhere (see user-domain `profile.id` convention; do not invent a
+  migration beyond this table).
+- **Bounded growth:** cap at **N most-recent rows per user** (default 50) — on
+  record, prune the user's older rows past the cap (or a scheduled cleanup).
 - **Record** best-effort after a successful authed search (failure to record
   MUST NOT fail the search). **Read** returns the caller's recent searches;
   **clear** deletes the caller's rows. All authed, owner-only, `private, no-store`.
@@ -118,5 +137,9 @@ Route (Zod params + wrapper responseSchema)
 
 ## Open Questions
 
-- Exact `ADULT_RATINGS` set + where the opt-in preference is read on `profile`
-  (confirm against live schema during task 4, mirroring user-domain conventions).
+- `ADULT_RATINGS` candidate set = MAL adult ratings `Rx - Hentai` (and, per a
+  product call, `R+ - Mild Nudity`); finalize the exact strings against live
+  `anime.rating` values in task 4.
+- **Resolved:** `profile` has no parental opt-in column today, so Stage-1 ships
+  **safe-only** (fail-closed). Enabling `full` requires a prerequisite migration
+  that adds the preference field — out of scope for this change.

--- a/openspec/changes/advanced-anime-search/proposal.md
+++ b/openspec/changes/advanced-anime-search/proposal.md
@@ -21,10 +21,14 @@ and pgvector (Stage 3) can be swapped in later **without an API change**.
   **score range** (`scoreMin`/`scoreMax`).
 - Add **configurable sort** (`sort` field + `order` direction) over a whitelist.
 - Add a **parental-control floor**: adult ratings excluded by default; included
-  only for an authenticated user who opted in. Modeled as a **coarse cache-key
-  variant** (`safe` / `full`), never per user id (`ROADMAP.md` D5).
+  only for an authenticated, opted-in user. Modeled as a **coarse cache-key
+  variant** (`safe` / `full`), never per user id — **catalog `GET /api/anime`
+  responses stay shared-cacheable**, keyed by normalized filters + `parentalVariant`
+  (`ROADMAP.md` D5).
 - Add **search history**: persist an authenticated user's executed searches;
-  expose read + clear. Anonymous searches are not persisted (`private, no-store`).
+  expose read + clear. Anonymous searches are not persisted. **Only the
+  authenticated history responses are `private, no-store`; catalog search
+  responses remain cacheable.**
 - Wire everything through the existing pipeline (request schema → filters mapper →
   repository query → cache key) using the standard wrapper composition
   (`withZodValidation(...)(withErrorHandling(handler, { responseSchema }))`).

--- a/openspec/changes/advanced-anime-search/specs/anime/advanced-search/spec.md
+++ b/openspec/changes/advanced-anime-search/specs/anime/advanced-search/spec.md
@@ -29,29 +29,41 @@ rejected at the request boundary.
 #### Scenario: Backward compatibility
 
 - **WHEN** a client requests `GET /api/anime` with only the pre-existing params
-- **THEN** the response shape and results are unchanged from before this change
+- **THEN** the response **shape** and the behavior of those filters are unchanged
+  from before this change — with the sole exception that the new parental-control
+  **safe** floor now applies to anonymous and non-opted-in callers (see the
+  parental-control requirement)
 
 ### Requirement: Configurable sort over a whitelist
 
-The system MUST accept `sort` (one of a fixed whitelist, e.g. `score`, `year`,
-`title`, `relevance`) and `order` (`asc` / `desc`). Values outside the whitelist
-MUST be rejected. `relevance` MUST be valid only when a `query` term is present.
-Raw sort input MUST NOT be interpolated into SQL.
+The system MUST accept `sort` from the exact whitelist `{ score, year, title,
+relevance }` (default `score`) and `order` from `{ asc, desc }` (default `desc`).
+`order` supplied without `sort` MUST use the default sort. Values outside either
+whitelist MUST be rejected. `relevance` MUST be valid only when `query` is present
+and **non-empty after trimming whitespace**. Every sort MUST append a unique
+secondary key (`malId`) so paginated results are deterministic across adjacent
+pages. Raw sort input MUST NOT be interpolated into SQL.
 
 #### Scenario: Sort by score descending
 
 - **WHEN** a client requests `GET /api/anime?sort=score&order=desc`
 - **THEN** results are ordered by score, highest first
 
-#### Scenario: Relevance sort without a query
+#### Scenario: Relevance sort without a usable query
 
-- **WHEN** a client requests `sort=relevance` with no `query`
+- **WHEN** a client requests `sort=relevance` with no `query`, or a
+  whitespace-only `query`
 - **THEN** the system responds `400 VALIDATION_ERROR`
 
 #### Scenario: Unknown sort field
 
 - **WHEN** a client requests a `sort` value outside the whitelist
 - **THEN** the system responds `400 VALIDATION_ERROR`
+
+#### Scenario: Deterministic pagination
+
+- **WHEN** a client pages through the same sorted search via `LIMIT`/`OFFSET`
+- **THEN** adjacent pages neither duplicate nor skip rows (ties broken by `malId`)
 
 ### Requirement: Indexed free-text relevance (Stage 1)
 
@@ -70,8 +82,13 @@ scan. The API contract for `query` MUST remain unchanged so later ranking stages
 The system MUST exclude adult-rated anime by default (the `safe` variant) for
 anonymous callers and authenticated users who have not opted in. Adult-rated
 anime MUST be included only for an authenticated user whose preference opts in
-(the `full` variant). The parental variant MUST be a coarse cache-key dimension
-(`safe` / `full`) and MUST NOT be keyed by user id.
+(the `full` variant). Resolution MUST be **fail-closed**: if the opt-in
+preference or the adult-ratings configuration cannot be read, the system MUST use
+`safe` and MUST NOT select `full`. The parental variant MUST be a coarse
+cache-key dimension (`safe` / `full`) and MUST NOT be keyed by user id.
+
+> Note: no parental opt-in field exists on `profile` yet, so this change ships
+> `safe`-only (fail-closed); enabling `full` requires a prerequisite migration.
 
 #### Scenario: Anonymous caller gets the safe catalog
 
@@ -95,6 +112,13 @@ on a best-effort basis, and MUST expose authenticated, owner-only endpoints to
 read recent searches and to clear them. Anonymous searches MUST NOT be persisted.
 A failure to record history MUST NOT fail the search request. History responses
 MUST NOT be cached (`private, no-store`).
+
+**HTTP contract:** history endpoints MUST use the same response envelope/wrapper
+as the anime API route. A read entry MUST expose `{ id, query, filters, createdAt }`,
+ordered **newest-first**, bounded by a `limit` (default 20, max 100); an empty
+history MUST return an empty list (`200`), not an error. Clear MUST return a
+success envelope reporting the number of rows removed. Unauthenticated access MUST
+return the standard `401` authentication-error envelope and touch no data.
 
 #### Scenario: Search is recorded for an authenticated user
 

--- a/openspec/changes/advanced-anime-search/tasks.md
+++ b/openspec/changes/advanced-anime-search/tasks.md
@@ -11,20 +11,21 @@
 
 ## 3. Repository query (TDD)
 
-- [ ] 3.1 Write failing tests (Vitest + Postgres service container) for: `season` equality, score range (nulls excluded when bounded), whitelist `sort`/`order`, and `pg_trgm`/`tsvector` text match ranking
+- [ ] 3.1 Write failing tests (Vitest + Postgres service container) for: `season` equality, score range (nulls excluded when bounded), whitelist `sort`/`order` with defaults, index-backed text predicate + ranking, and **deterministic pagination** across adjacent `LIMIT/OFFSET` pages for `score`/`year`/`title`/`relevance` (tie-break by `malId`)
 - [ ] 3.2 Add migration: `CREATE EXTENSION IF NOT EXISTS pg_trgm`, GIN trigram index on `anime.title` (+ `anime_title_synonym`), `tsvector` expression/index as needed
-- [ ] 3.3 Implement the extended query in the anime repository: indexed text match replacing `ILIKE`, new filters, and strict whitelist sort (no raw interpolation)
+- [ ] 3.3 Implement the extended query: **index-backed match predicate** (`title % :q` / `tsvector @@ plainto_tsquery`) before `similarity()`/`ts_rank`, new filters, and strict whitelist sort with **`malId` secondary key** (no raw interpolation)
 
 ## 4. Parental floor + service (TDD)
 
-- [ ] 4.1 Write failing tests for `parentalVariant` resolution (anonymous → `safe`; authed opt-in → `full`) and that `safe` excludes `ADULT_RATINGS`
-- [ ] 4.2 Confirm `ADULT_RATINGS` set + opt-in preference location against live `profile` schema (mirror user-domain conventions; no drive-by migration)
+- [ ] 4.1 Write failing tests for `parentalVariant` resolution: anonymous → `safe`; **fail-closed** (unreadable preference/config → `safe`, never `full`); `safe` excludes `ADULT_RATINGS`
+- [ ] 4.2 Finalize `ADULT_RATINGS` strings against live `anime.rating` values. **Note: `profile` has no opt-in column → Stage-1 is safe-only**; do NOT add the preference field here (prerequisite change). Ship the `full` plumbing but leave it unreachable
 - [ ] 4.3 Implement variant resolution in `animeListService.getAnimeList` and fold the variant into `animeListCache.key`
 - [ ] 4.4 Write failing test proving cache produces at most `safe`/`full` variants per filter set (never keyed by user id)
 
 ## 5. Search history unit (TDD)
 
-- [ ] 5.1 Add migration for `search_history` (`id`, `user_id` text, `query` text, `filters` jsonb, `created_at`)
+- [ ] 5.1 Add migration for `search_history` (`id`, `user_id` text, `query` text, `filters` jsonb, `created_at`) + **index on (`user_id`, `created_at` DESC)**; enforce a **per-user row cap** (default 50) by pruning on record
+- [ ] 5.1a Write failing test proving history read is newest-first, `limit` default 20 / max 100, empty history → empty list, and per-user cap prunes older rows
 - [ ] 5.2 Write failing tests for `searchHistoryRepository` (record / list-by-user / clear-by-user, `dbError` on failure)
 - [ ] 5.3 Implement repository + `searchHistoryService` (owner-only) as anime-domain unit folders
 - [ ] 5.4 Write failing test proving `record` is best-effort: a history write failure does NOT fail the search
@@ -32,7 +33,7 @@
 ## 6. API routes (TDD)
 
 - [ ] 6.1 Write failing route tests for extended `GET /api/anime` (new params validate; existing behavior unchanged; parental variant applied; history recorded when session present)
-- [ ] 6.2 Migrate/keep `GET /api/anime` on `withZodValidation(...)(withErrorHandling(handler, { responseSchema }))`; wire new filters + best-effort history record
+- [ ] 6.2 Migrate/keep `GET /api/anime` on `withZodValidation(...)(withErrorHandling(handler, { responseSchema }))` (**after** `api-response-schema-in-wrapper` lands; **remove** inline `animeListResponseSchema.parse` + success-path `jsonResponse`); wire new filters + best-effort history record
 - [ ] 6.3 Write failing tests for `GET`/`DELETE /api/anime/search-history` (401 anon, 200 owner list, 200 clear)
 - [ ] 6.4 Implement authed search-history read + clear routes (`private, no-store`)
 


### PR DESCRIPTION
## Summary

This PR updates the roadmap and adds the initial design/specification for advanced anime search.

### What's included

- Defines Stage 1 advanced search filters, sorting, pagination, and indexed free-text search.
- Adds deterministic pagination using `malId` as a secondary sort key.
- Specifies fail-closed parental filtering with `safe`/`full` cache variants.
- Documents search-history persistence, ownership, limits, pruning, and API contracts.
- Clarifies transactional, FK-safe catalog promotion from the backfill environment to production.
- Refines scraper rate-limiting, caching, and integration-testing policies.
- Adds the advanced anime search proposal, design, specification, and TDD task breakdown.

### Notes

- Studio/producer and broadcast-day filters remain deferred until the required catalog backfill.
- Stage 1 is safe-only because the current `profile` schema has no parental opt-in field.
- The implementation depends on the `api-response-schema-in-wrapper` change landing first.
- Existing checks pass: **2/2**.