### PR TITLE
feat(http): validate API responses via the wrapper's responseSchema option

### DIFF
--- a/openspec/changes/api-response-schema-in-wrapper/tasks.md
+++ b/openspec/changes/api-response-schema-in-wrapper/tasks.md
@@ -10,27 +10,33 @@
 
 ## 2. Refactor anime routes
 
-- [ ] 2.1 Refactor `GET /api/anime` (`anime/index.ts`) to `withErrorHandling(handler, { responseSchema: animeListResponseSchema })`, preserving `meta` (stale/page/total/hasNext) and `x-stale` header
-- [ ] 2.2 Refactor `GET /api/anime/:malId` (`anime/[malId]/index.ts`) with `animeDetailsResponseSchema`
-- [ ] 2.3 Refactor `GET /api/anime/:malId/characters` with `animeCharacterResponseSchema`
-- [ ] 2.4 Refactor `GET /api/anime/:malId/full` with `animeFullDetailsResponseSchema`
-- [ ] 2.5 Refactor `GET /api/anime/:malId/staff` with `animeStaffResponseSchema`
+- [x] 2.1 `GET /api/anime` → `withErrorHandling(handler, { responseSchema: animeListResponseSchema })`, preserving `meta` (stale/page/total/hasNext) and `x-stale`
+- [x] 2.2 `GET /api/anime/:malId` with `animeDetailsResponseSchema`
+- [x] 2.3 `GET /api/anime/:malId/characters` with `animeCharacterResponseSchema`
+- [x] 2.4 `GET /api/anime/:malId/full` with `animeFullDetailsResponseSchema`
+- [x] 2.5 `GET /api/anime/:malId/staff` with `animeStaffResponseSchema`
 
 ## 3. Refactor music routes
 
-- [ ] 3.1 Refactor `GET /api/music` (`music/index.ts`) with `musicListResponseSchema`, preserving pagination meta and `x-stale`
-- [ ] 3.2 Refactor `GET /api/music/:id` (`music/[id].ts`) with `musicDetailsResponseSchema`
+- [x] 3.1 `GET /api/music` with `musicListResponseSchema`, preserving pagination meta and `x-stale`
+- [x] 3.2 `GET /api/music/:id` with `musicDetailsResponseSchema`
 
 ## 4. Refactor user routes
 
-- [ ] 4.1 Refactor `GET /api/user/:userId` to pass `{ responseSchema: userProfileResponseSchema }`
-- [ ] 4.2 Refactor `POST /api/user` to pass `{ responseSchema: userProfileResponseSchema }`
-- [ ] 4.3 Refactor `PATCH /api/user/:userId` to pass `{ responseSchema: userProfileResponseSchema }`
+- [x] 4.1 `GET /api/user/:userId` passes `{ responseSchema: userProfileResponseSchema }`
+- [x] 4.2 `POST /api/user` passes `{ responseSchema: userProfileResponseSchema }`
+- [x] 4.3 `PATCH /api/user/:userId` passes `{ responseSchema: userProfileResponseSchema }`
+
+> ⚠️ **Bug surfaced by the wrapper:** `userProfileSchema.avatar` used `z.url()`
+> (absolute URL), but real avatars are relative media/proxy paths
+> (`/placeholder.webp`). Enabling response validation would 500 valid profiles,
+> so `avatar` was loosened to `z.string()` (text; relative or absolute). Anime
+> card `imageUrl`/`smallImageUrl` stay `z.url()` (mapper emits absolute proxy URLs).
 
 ## 5. Route tests for migrated routes
 
-- [ ] 5.1 Add/extend route tests verifying migrated routes still return 200 success envelopes and 4xx/5xx errors
-- [ ] 5.2 Add a wrapper-level test that a route with a response schema returns 500 `RESPONSE_VALIDATION_ERROR` on invalid `data`
+- [x] 5.1 Migrated-route coverage: user route tests (create/update/get) exercise the composition + response schema (and caught the avatar bug); new `anime-list-route.test.ts` covers `GET /api/anime` (200 envelope + malformed → 500). Music GET routes share the identical composition
+- [x] 5.2 Wrapper-level test (`with-error-handling.test.ts`): response schema → 500 `RESPONSE_VALIDATION_ERROR` on invalid data
 
 ## 6. Verification
 

--- a/openspec/changes/api-response-schema-in-wrapper/tasks.md
+++ b/openspec/changes/api-response-schema-in-wrapper/tasks.md
@@ -40,5 +40,5 @@
 
 ## 6. Verification
 
-- [ ] 6.1 Run `bun run format`, `bun run check`, `bun run check:types`, `bun run test`, `bun run build`
-- [ ] 6.2 Mark tasks complete; Conventional Commits per task group; release only when user requests PR/release per AGENTS.md
+- [x] 6.1 Gate green: `format` ✓ · `check` ✓ · `check:types` 0 errors ✓ · `test` 115 passed ✓ · `build` Complete ✓
+- [x] 6.2 Conventional Commits per task group; PR/release only when the user requests it

--- a/openspec/changes/api-response-schema-in-wrapper/tasks.md
+++ b/openspec/changes/api-response-schema-in-wrapper/tasks.md
@@ -1,8 +1,12 @@
 ## 1. Wrapper option and error code (TDD)
 
-- [ ] 1.1 Add failing tests for `withErrorHandling(handler, { responseSchema })`: valid data passes, invalid data yields 500, no schema skips validation
-- [ ] 1.2 Add `ErrorCodes.RESPONSE_VALIDATION_ERROR` and map it to HTTP 500 with `error` severity in `mapErrorToHttp` (add failing tests first)
-- [ ] 1.3 Implement the `responseSchema` option in `withErrorHandling` (safeParse on success, throw on invalid)
+- [x] 1.1 Failing tests for `withErrorHandling(handler, { responseSchema })`: valid passes, invalid → 500, no schema skips
+- [x] 1.2 `ErrorCodes.RESPONSE_VALIDATION_ERROR` + `ResponseValidationError` class (BaseError, severity `error`) mapped to **500** (generic message, no leaked details) in `mapErrorToHttp`
+- [x] 1.3 `responseSchema` option in `withErrorHandling` — validates the built **envelope** payload (matches the `*ResponseSchema` = `createApiResponseSchema` shape); throws `ResponseValidationError` on mismatch
+
+> Note: the schema validates the full success envelope (`{ data, status, meta }`),
+> not just `data` — the existing `*ResponseSchema` are envelope schemas, matching
+> what routes previously did with `*.parse(payload)`.
 
 ## 2. Refactor anime routes
 

--- a/src/domains/user/schemas/user-schema.ts
+++ b/src/domains/user/schemas/user-schema.ts
@@ -12,7 +12,7 @@
  * | Field | Type | Required | Description |
  * | ----- | ---- | -------- | ----------- |
  * | `id` | `string` | yes | Unique profile identifier |
- * | `avatar` | URL `string` | no | Profile image URL |
+ * | `avatar` | `string` | no | Absolute URL or origin-relative path (`/...`) |
  * | `name` | `string` (min 1) | yes | Given name |
  * | `lastName` | `string` (min 1) | yes | Family name |
  * | `birthday` | `string` | no | ISO or display date string |
@@ -60,9 +60,11 @@ import {
  */
 export const userProfileSchema = z.object({
   id: z.string(),
-  // Stored as text; may be a relative media/proxy path (e.g. '/placeholder.webp')
-  // or an absolute URL — not necessarily a full URL, so do not use z.url().
-  avatar: z.string().optional(),
+  // Either an absolute URL (OAuth/CDN) or an origin-relative media/proxy path
+  // beginning with a single '/' (e.g. '/placeholder.webp'). Rejects empty,
+  // arbitrary, and protocol-relative ('//host') strings. Not a plain z.string()
+  // (too loose) nor z.url() (would 500 valid relative-path avatars).
+  avatar: z.union([z.url(), z.string().regex(/^\/(?!\/)/)]).optional(),
   name: z.string().min(1),
   lastName: z.string().min(1),
   birthday: z.string().optional(),

--- a/src/domains/user/schemas/user-schema.ts
+++ b/src/domains/user/schemas/user-schema.ts
@@ -60,7 +60,9 @@ import {
  */
 export const userProfileSchema = z.object({
   id: z.string(),
-  avatar: z.url().optional(),
+  // Stored as text; may be a relative media/proxy path (e.g. '/placeholder.webp')
+  // or an absolute URL — not necessarily a full URL, so do not use z.url().
+  avatar: z.string().optional(),
   name: z.string().min(1),
   lastName: z.string().min(1),
   birthday: z.string().optional(),

--- a/src/pages/api/anime/[malId]/characters.ts
+++ b/src/pages/api/anime/[malId]/characters.ts
@@ -64,6 +64,7 @@ import { withZodValidation } from '@http/with-validation'
  * | 500 | `DB_ERROR` | Database query failed |
  * | 500 | `CACHE_ERROR` | Cache read/write failure |
  * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ * | 500 | `RESPONSE_VALIDATION_ERROR` | Response envelope fails its Zod schema (wrapper-level) |
  *
  * @example
  * ```bash

--- a/src/pages/api/anime/[malId]/characters.ts
+++ b/src/pages/api/anime/[malId]/characters.ts
@@ -15,16 +15,14 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping
  */
 
-import type { APIRoute } from 'astro'
+import type { APIContext, APIRoute } from 'astro'
 import { animeCharacterService } from '@anime/services/anime-characters'
 import {
   getAnimeCharacterSchema,
   animeCharacterResponseSchema,
 } from '@anime/schemas/anime-character-schema'
+import { withErrorHandling } from '@http/with-error-handling'
 import { withZodValidation } from '@http/with-validation'
-import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
-import { jsonResponse } from '@shared/http/api-response-serialize-util'
-import { logger } from '@shared/utils/logger-util'
 
 /**
  * Returns the character list for a MyAnimeList anime ID.
@@ -80,14 +78,15 @@ import { logger } from '@shared/utils/logger-util'
  * ```
  */
 export const GET: APIRoute = withZodValidation(getAnimeCharacterSchema)(
-  async ({ validated }) => {
-    try {
+  withErrorHandling(
+    async ({
+      validated,
+    }: APIContext & { validated: { params: { malId: number } } }) => {
       const { malId } = validated.params
-
       const { value: characters, isStale } =
         await animeCharacterService.getAnimeCharacters(malId)
 
-      const payload = {
+      return {
         data: characters,
         status: 200,
         meta: {
@@ -95,26 +94,7 @@ export const GET: APIRoute = withZodValidation(getAnimeCharacterSchema)(
           count: characters.length,
         },
       }
-      const responseBody = animeCharacterResponseSchema.parse(payload)
-
-      return jsonResponse(responseBody, undefined, 200)
-    } catch (error) {
-      logger.error(
-        { err: error, malId: validated.params.malId },
-        'Failed to get anime characters'
-      )
-      const { status, body } = mapErrorToHttp(error)
-      const payload = {
-        data: null,
-        status,
-        error: body.message ?? 'Unexpected error',
-        meta: body.meta ?? {},
-      }
-
-      return new Response(JSON.stringify(payload), {
-        status,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-  }
+    },
+    { responseSchema: animeCharacterResponseSchema }
+  )
 )

--- a/src/pages/api/anime/[malId]/full.ts
+++ b/src/pages/api/anime/[malId]/full.ts
@@ -16,11 +16,10 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping
  */
 
-import type { APIRoute } from 'astro'
+import type { APIContext, APIRoute } from 'astro'
+import { withErrorHandling } from '@http/with-error-handling'
 import { withZodValidation } from '@http/with-validation'
 import { animeFullService } from '@anime/services/anime-full'
-import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
-import { jsonResponse } from '@shared/http/api-response-serialize-util'
 import {
   animeFullDetailsResponseSchema,
   getAnimeFullSchema,
@@ -92,35 +91,20 @@ import {
  * ```
  */
 export const GET: APIRoute = withZodValidation(getAnimeFullSchema)(
-  async ({ validated }) => {
-    try {
+  withErrorHandling(
+    async ({
+      validated,
+    }: APIContext & { validated: { params: { malId: number } } }) => {
       const { malId } = validated.params
-
       const { value: anime, isStale } =
         await animeFullService.getAnimeFullByMalId(malId)
 
-      const payload = {
+      return {
         data: anime,
         status: 200,
         meta: { stale: isStale },
       }
-
-      const responseBody = animeFullDetailsResponseSchema.parse(payload)
-
-      return jsonResponse(responseBody, undefined, 200)
-    } catch (error) {
-      const { status, body } = mapErrorToHttp(error)
-      const payload = {
-        data: null,
-        status,
-        error: body.message ?? 'Unexpected error',
-        meta: body.meta ?? {},
-      }
-
-      return new Response(JSON.stringify(payload), {
-        status,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-  }
+    },
+    { responseSchema: animeFullDetailsResponseSchema }
+  )
 )

--- a/src/pages/api/anime/[malId]/full.ts
+++ b/src/pages/api/anime/[malId]/full.ts
@@ -77,6 +77,7 @@ import {
  * | 500 | `DB_ERROR` | Database query failed |
  * | 500 | `CACHE_ERROR` | Cache read/write failure |
  * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ * | 500 | `RESPONSE_VALIDATION_ERROR` | Response envelope fails its Zod schema (wrapper-level) |
  *
  * @example
  * ```bash

--- a/src/pages/api/anime/[malId]/index.ts
+++ b/src/pages/api/anime/[malId]/index.ts
@@ -15,11 +15,10 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping
  */
 
-import type { APIRoute } from 'astro'
+import type { APIContext, APIRoute } from 'astro'
+import { withErrorHandling } from '@http/with-error-handling'
 import { withZodValidation } from '@http/with-validation'
 import { animeService } from '@anime/services/anime'
-import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
-import { jsonResponse } from '@shared/http/api-response-serialize-util'
 import {
   animeDetailsResponseSchema,
   getAnimeDetailsSchema,
@@ -87,36 +86,20 @@ import {
  * ```
  */
 export const GET: APIRoute = withZodValidation(getAnimeDetailsSchema)(
-  async ({ validated }) => {
-    try {
+  withErrorHandling(
+    async ({
+      validated,
+    }: APIContext & { validated: { params: { malId: number } } }) => {
       const { malId } = validated.params
-
       const { value: anime, isStale } =
         await animeService.getAnimeDetails(malId)
 
-      const payload = {
+      return {
         data: anime,
         status: 200,
         meta: { stale: isStale },
       }
-
-      const responseBody = animeDetailsResponseSchema.parse(payload)
-
-      return jsonResponse(responseBody, undefined, 200)
-    } catch (error) {
-      const { status, body } = mapErrorToHttp(error)
-
-      const payload = {
-        data: null,
-        status,
-        error: body.message ?? 'Unexpected error',
-        meta: body.meta ?? {},
-      }
-
-      return new Response(JSON.stringify(payload), {
-        status,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-  }
+    },
+    { responseSchema: animeDetailsResponseSchema }
+  )
 )

--- a/src/pages/api/anime/[malId]/index.ts
+++ b/src/pages/api/anime/[malId]/index.ts
@@ -72,6 +72,7 @@ import {
  * | 500 | `DB_ERROR` | Database query failed |
  * | 500 | `CACHE_ERROR` | Cache read/write failure |
  * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ * | 500 | `RESPONSE_VALIDATION_ERROR` | Response envelope fails its Zod schema (wrapper-level) |
  *
  * @example
  * ```bash

--- a/src/pages/api/anime/[malId]/staff.ts
+++ b/src/pages/api/anime/[malId]/staff.ts
@@ -15,15 +15,14 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping
  */
 
-import type { APIRoute } from 'astro'
+import type { APIContext, APIRoute } from 'astro'
 import { animeStaffService } from '@anime/services/anime-staff'
 import {
   getAnimeStaffSchema,
   animeStaffResponseSchema,
 } from '@anime/schemas/anime-staff-schema'
+import { withErrorHandling } from '@http/with-error-handling'
 import { withZodValidation } from '@http/with-validation'
-import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
-import { jsonResponse } from '@shared/http/api-response-serialize-util'
 
 /**
  * Returns the staff list for a MyAnimeList anime ID.
@@ -72,14 +71,15 @@ import { jsonResponse } from '@shared/http/api-response-serialize-util'
  * ```
  */
 export const GET: APIRoute = withZodValidation(getAnimeStaffSchema)(
-  async ({ validated }) => {
-    try {
+  withErrorHandling(
+    async ({
+      validated,
+    }: APIContext & { validated: { params: { malId: number } } }) => {
       const { malId } = validated.params
-
       const { value: staff, isStale } =
         await animeStaffService.getAnimeStaff(malId)
 
-      const payload = {
+      return {
         data: staff,
         status: 200,
         meta: {
@@ -87,22 +87,7 @@ export const GET: APIRoute = withZodValidation(getAnimeStaffSchema)(
           count: staff.length,
         },
       }
-      const responseBody = animeStaffResponseSchema.parse(payload)
-
-      return jsonResponse(responseBody, undefined, 200)
-    } catch (error) {
-      const { status, body } = mapErrorToHttp(error)
-      const payload = {
-        data: null,
-        status,
-        error: body.message ?? 'Unexpected error',
-        meta: body.meta ?? {},
-      }
-
-      return new Response(JSON.stringify(payload), {
-        status,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-  }
+    },
+    { responseSchema: animeStaffResponseSchema }
+  )
 )

--- a/src/pages/api/anime/[malId]/staff.ts
+++ b/src/pages/api/anime/[malId]/staff.ts
@@ -57,6 +57,7 @@ import { withZodValidation } from '@http/with-validation'
  * | 500 | `DB_ERROR` | Database query failed |
  * | 500 | `CACHE_ERROR` | Cache read/write failure |
  * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ * | 500 | `RESPONSE_VALIDATION_ERROR` | Response envelope fails its Zod schema (wrapper-level) |
  *
  * @example
  * ```bash

--- a/src/pages/api/anime/__tests__/anime-list-route.test.ts
+++ b/src/pages/api/anime/__tests__/anime-list-route.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Route tests for `GET /api/anime` after adopting the response-schema wrapper.
+ *
+ * @module pages/api/anime/__tests__/anime-list-route
+ * @remarks
+ * Verifies the migrated route returns a 200 success envelope and that malformed
+ * handler output is rejected as 500 `RESPONSE_VALIDATION_ERROR` by the wrapper.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@config/env', () => ({
+  env: {
+    NODE_ENV: 'test',
+    DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+    REDIS_URL: 'redis://localhost:6379',
+    APP_BASE_URL: 'http://localhost:4321',
+    BETTER_AUTH_SECRET: 'test-secret-test-secret-test-secret-test-secret',
+    LOG_LEVEL: 'silent',
+  },
+}))
+
+const { getAnimeListMock } = vi.hoisted(() => ({ getAnimeListMock: vi.fn() }))
+vi.mock('@anime/services/anime-list', () => ({
+  animeListService: { getAnimeList: getAnimeListMock },
+}))
+
+const { GET } = await import('../index')
+
+const validCard = {
+  malId: 1,
+  title: 'Cowboy Bebop',
+  year: 1998,
+  status: 'Finished Airing',
+  score: 8.75,
+  type: 'TV',
+  imageUrl: 'https://cdn.example.com/1.webp',
+  smallImageUrl: 'https://cdn.example.com/1t.webp',
+  altImageText: 'Cowboy Bebop',
+}
+
+const call = (url = 'http://localhost:4321/api/anime?page=1&limit=10') =>
+  (GET as unknown as (ctx: unknown) => Promise<Response>)({
+    request: new Request(url),
+    locals: {},
+  })
+
+describe('GET /api/anime — response wrapper', () => {
+  it('returns a 200 success envelope with pagination meta', async () => {
+    getAnimeListMock.mockResolvedValueOnce({
+      value: { list: [validCard], total: 1 },
+      isStale: false,
+    })
+
+    const res = await call()
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.data).toEqual([validCard])
+    expect(body.meta.page).toBe(1)
+    expect(body.meta.hasNext).toBe(false)
+  })
+
+  it('returns 500 RESPONSE_VALIDATION_ERROR when a card is malformed', async () => {
+    getAnimeListMock.mockResolvedValueOnce({
+      value: { list: [{ ...validCard, imageUrl: 'not-a-url' }], total: 1 },
+      isStale: false,
+    })
+
+    const res = await call()
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.code).toBe('RESPONSE_VALIDATION_ERROR')
+    expect(body.data).toBeNull()
+  })
+})

--- a/src/pages/api/anime/index.ts
+++ b/src/pages/api/anime/index.ts
@@ -15,15 +15,15 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping
  */
 
-import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
-import { jsonResponse } from '@shared/http/api-response-serialize-util'
+import { withErrorHandling } from '@http/with-error-handling'
 import { withZodValidation } from '@http/with-validation'
 import {
   animeListRequestSchema,
   animeListResponseSchema,
 } from '@anime/schemas/anime-list-schema'
 import { animeListService } from '@anime/services/anime-list'
-import type { APIRoute } from 'astro'
+import type { AnimeFiltersParams } from '@anime/types'
+import type { APIContext, APIRoute } from 'astro'
 
 /**
  * Returns a paginated, filterable anime card list.
@@ -88,13 +88,16 @@ import type { APIRoute } from 'astro'
  * ```
  */
 export const GET: APIRoute = withZodValidation(animeListRequestSchema)(
-  async ({ validated }) => {
-    try {
+  withErrorHandling(
+    async ({
+      validated,
+    }: APIContext & { validated: { query: AnimeFiltersParams } }) => {
       const {
         value: { list: animeCards, total },
         isStale,
       } = await animeListService.getAnimeList(validated.query)
-      const payload = {
+
+      return {
         data: animeCards,
         status: 200,
         meta: {
@@ -104,22 +107,7 @@ export const GET: APIRoute = withZodValidation(animeListRequestSchema)(
           hasNext: validated.query.page * validated.query.limit < total,
         },
       }
-      const responseBody = animeListResponseSchema.parse(payload)
-
-      return jsonResponse(responseBody)
-    } catch (error) {
-      const { status, body } = mapErrorToHttp(error)
-      const payload = {
-        data: null,
-        status,
-        error: body.message ?? 'Unexpected error',
-        meta: body.meta ?? {},
-      }
-
-      return new Response(JSON.stringify(payload), {
-        status,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-  }
+    },
+    { responseSchema: animeListResponseSchema }
+  )
 )

--- a/src/pages/api/anime/index.ts
+++ b/src/pages/api/anime/index.ts
@@ -74,6 +74,7 @@ import type { APIContext, APIRoute } from 'astro'
  * | 500 | `DB_ERROR` | Database query failed |
  * | 500 | `CACHE_ERROR` | Cache read/write failure |
  * | 500 | `UNKNOWN_ERROR` | Unhandled throwable |
+ * | 500 | `RESPONSE_VALIDATION_ERROR` | Response envelope fails its Zod schema (wrapper-level) |
  *
  * @example
  * ```bash

--- a/src/pages/api/music/[id].ts
+++ b/src/pages/api/music/[id].ts
@@ -15,11 +15,10 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping
  */
 
-import type { APIRoute } from 'astro'
+import type { APIContext, APIRoute } from 'astro'
+import { withErrorHandling } from '@http/with-error-handling'
 import { withZodValidation } from '@http/with-validation'
 import { musicService } from '@music/services/music'
-import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
-import { jsonResponse } from '@shared/http/api-response-serialize-util'
 import {
   getMusicSchema,
   musicDetailsResponseSchema,
@@ -85,33 +84,20 @@ import {
  * ```
  */
 export const GET: APIRoute = withZodValidation(getMusicSchema)(
-  async ({ validated }) => {
-    try {
+  withErrorHandling(
+    async ({
+      validated,
+    }: APIContext & { validated: { params: { id: string } } }) => {
       const { id } = validated.params
       const { value: musicDetails, isStale } =
         await musicService.getMusicDetailsById(Number(id))
 
-      const payload = {
+      return {
         data: musicDetails,
         status: 200,
         meta: { stale: isStale },
       }
-      const responseBody = musicDetailsResponseSchema.parse(payload)
-
-      return jsonResponse(responseBody, undefined, 200)
-    } catch (error) {
-      const { body, status } = mapErrorToHttp(error)
-      const payload = {
-        data: null,
-        status,
-        error: body.message ?? 'Unexpected error',
-        meta: body.meta ?? {},
-      }
-
-      return new Response(JSON.stringify(payload), {
-        status: status,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-  }
+    },
+    { responseSchema: musicDetailsResponseSchema }
+  )
 )

--- a/src/pages/api/music/index.ts
+++ b/src/pages/api/music/index.ts
@@ -15,15 +15,15 @@
  * @see {@link mapErrorToHttp} — error-to-HTTP mapping
  */
 
-import { mapErrorToHttp } from '@shared/errors/map-error-to-http'
-import { jsonResponse } from '@shared/http/api-response-serialize-util'
+import { withErrorHandling } from '@http/with-error-handling'
 import { withZodValidation } from '@http/with-validation'
 import {
   musicListRequestSchema,
   musicListResponseSchema,
 } from '@music/schemas/music-list-schema'
 import { musicListService } from '@music/services/music-list'
-import type { APIRoute } from 'astro'
+import type { MusicListFiltersParams } from '@music/types'
+import type { APIContext, APIRoute } from 'astro'
 
 /**
  * Returns a paginated, filterable music card list.
@@ -80,13 +80,16 @@ import type { APIRoute } from 'astro'
  * ```
  */
 export const GET: APIRoute = withZodValidation(musicListRequestSchema)(
-  async ({ validated }) => {
-    try {
+  withErrorHandling(
+    async ({
+      validated,
+    }: APIContext & { validated: { query: MusicListFiltersParams } }) => {
       const {
         value: { list: musicCards, total },
         isStale,
       } = await musicListService.getMusicList(validated.query)
-      const payload = {
+
+      return {
         data: musicCards,
         status: 200,
         meta: {
@@ -96,22 +99,7 @@ export const GET: APIRoute = withZodValidation(musicListRequestSchema)(
           hasNext: validated.query.page * validated.query.limit < total,
         },
       }
-      const responseBody = musicListResponseSchema.parse(payload)
-
-      return jsonResponse(responseBody)
-    } catch (error) {
-      const { status, body } = mapErrorToHttp(error)
-      const payload = {
-        data: null,
-        status,
-        error: body.message ?? 'Unexpected error',
-        meta: body.meta ?? {},
-      }
-
-      return new Response(JSON.stringify(payload), {
-        status,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    }
-  }
+    },
+    { responseSchema: musicListResponseSchema }
+  )
 )

--- a/src/pages/api/user/[userId].ts
+++ b/src/pages/api/user/[userId].ts
@@ -24,7 +24,11 @@ import type { APIContext, APIRoute } from 'astro'
 import { withZodValidation } from '@http/with-validation'
 import { withErrorHandling } from '@http/with-error-handling'
 import { userService } from '@user/services/user'
-import { getUserProfileSchema, updateUserProfileSchema } from '@user/schemas'
+import {
+  getUserProfileSchema,
+  updateUserProfileSchema,
+  userProfileResponseSchema,
+} from '@user/schemas'
 import { requireAuthSession } from '@auth/utils'
 import { authForbidden } from '@shared/errors/auth-errors'
 import type { User } from '@lib/auth/server'
@@ -70,15 +74,18 @@ import type { User } from '@lib/auth/server'
  * ```
  */
 export const GET: APIRoute = withZodValidation(getUserProfileSchema)(
-  withErrorHandling(async ({ locals, validated }) => {
-    const { userId: targetId } = validated.params
-    const { user } = locals
-    const userProfile = await userService.getUserProfile({
-      userId: user?.id ?? 'anonymous',
-      targetId,
-    })
-    return { data: userProfile, status: 200, meta: {} }
-  })
+  withErrorHandling(
+    async ({ locals, validated }) => {
+      const { userId: targetId } = validated.params
+      const { user } = locals
+      const userProfile = await userService.getUserProfile({
+        userId: user?.id ?? 'anonymous',
+        targetId,
+      })
+      return { data: userProfile, status: 200, meta: {} }
+    },
+    { responseSchema: userProfileResponseSchema }
+  )
 )
 
 /**
@@ -124,19 +131,22 @@ export const GET: APIRoute = withZodValidation(getUserProfileSchema)(
  */
 export const PATCH: (context: APIContext) => Promise<Response> =
   withZodValidation(updateUserProfileSchema)(
-    withErrorHandling(async ({ locals, validated }) => {
-      const user = locals.user as User | null
-      const sessionId = requireAuthSession({ user })
-      const { userId: targetId } = validated.params
-      if (targetId !== sessionId) {
-        throw authForbidden({ targetId, sessionId })
-      }
+    withErrorHandling(
+      async ({ locals, validated }) => {
+        const user = locals.user as User | null
+        const sessionId = requireAuthSession({ user })
+        const { userId: targetId } = validated.params
+        if (targetId !== sessionId) {
+          throw authForbidden({ targetId, sessionId })
+        }
 
-      const profile = await userService.updateUserProfile({
-        userId: sessionId,
-        targetId,
-        input: validated,
-      })
-      return { data: profile, status: 200, meta: {} }
-    })
+        const profile = await userService.updateUserProfile({
+          userId: sessionId,
+          targetId,
+          input: validated,
+        })
+        return { data: profile, status: 200, meta: {} }
+      },
+      { responseSchema: userProfileResponseSchema }
+    )
   )

--- a/src/pages/api/user/index.ts
+++ b/src/pages/api/user/index.ts
@@ -23,7 +23,10 @@ import type { APIContext } from 'astro'
 import { withZodValidation } from '@http/with-validation'
 import { withErrorHandling } from '@http/with-error-handling'
 import { userService } from '@user/services/user'
-import { createUserProfileSchema } from '@user/schemas'
+import {
+  createUserProfileSchema,
+  userProfileResponseSchema,
+} from '@user/schemas'
 import { requireAuthSession } from '@auth/utils'
 import type { User } from '@lib/auth/server'
 
@@ -72,13 +75,16 @@ import type { User } from '@lib/auth/server'
  */
 export const POST: (context: APIContext) => Promise<Response> =
   withZodValidation(createUserProfileSchema)(
-    withErrorHandling(async ({ locals, validated }) => {
-      const user = locals.user as User | null
-      const userId = requireAuthSession({ user })
-      const profile = await userService.createUserProfile({
-        userId,
-        input: validated,
-      })
-      return { data: profile, status: 201, meta: {} }
-    })
+    withErrorHandling(
+      async ({ locals, validated }) => {
+        const user = locals.user as User | null
+        const userId = requireAuthSession({ user })
+        const profile = await userService.createUserProfile({
+          userId,
+          input: validated,
+        })
+        return { data: profile, status: 201, meta: {} }
+      },
+      { responseSchema: userProfileResponseSchema }
+    )
   )

--- a/src/shared/__tests__/http/with-error-handling.test.ts
+++ b/src/shared/__tests__/http/with-error-handling.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the `responseSchema` option of {@link withErrorHandling}.
+ *
+ * @module shared/__tests__/http/with-error-handling
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { createApiResponseSchema } from '@shared/schemas/api-schema'
+
+vi.mock('@config/env', () => ({ env: { NODE_ENV: 'test' } }))
+vi.mock('@utils/logger-util', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}))
+vi.mock('@shared/errors/capture-error', () => ({ captureError: vi.fn() }))
+
+const { withErrorHandling } = await import('@shared/http/with-error-handling')
+
+const context = {} as Parameters<ReturnType<typeof withErrorHandling>>[0]
+const itemSchema = createApiResponseSchema(z.array(z.object({ id: z.number() })))
+
+describe('withErrorHandling — responseSchema', () => {
+  it('passes through valid data and returns the success envelope', async () => {
+    const route = withErrorHandling(
+      () => ({ data: [{ id: 1 }], status: 200, meta: { page: 1 } }),
+      { responseSchema: itemSchema }
+    )
+    const res = await route(context)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.data).toEqual([{ id: 1 }])
+    expect(body.meta).toEqual({ page: 1 })
+  })
+
+  it('returns 500 RESPONSE_VALIDATION_ERROR when data is malformed', async () => {
+    const route = withErrorHandling(
+      () => ({ data: [{ id: 'not-a-number' }], status: 200 }),
+      { responseSchema: itemSchema }
+    )
+    const res = await route(context)
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.code).toBe('RESPONSE_VALIDATION_ERROR')
+    expect(body.data).toBeNull()
+  })
+
+  it('skips validation when no responseSchema is provided', async () => {
+    const route = withErrorHandling(() => ({
+      data: [{ id: 'anything' }],
+      status: 200,
+    }))
+    const res = await route(context)
+
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/shared/__tests__/http/with-error-handling.test.ts
+++ b/src/shared/__tests__/http/with-error-handling.test.ts
@@ -16,7 +16,9 @@ vi.mock('@shared/errors/capture-error', () => ({ captureError: vi.fn() }))
 const { withErrorHandling } = await import('@shared/http/with-error-handling')
 
 const context = {} as Parameters<ReturnType<typeof withErrorHandling>>[0]
-const itemSchema = createApiResponseSchema(z.array(z.object({ id: z.number() })))
+const itemSchema = createApiResponseSchema(
+  z.array(z.object({ id: z.number() }))
+)
 
 describe('withErrorHandling — responseSchema', () => {
   it('passes through valid data and returns the success envelope', async () => {

--- a/src/shared/errors/__tests__/map-error-to-http.test.ts
+++ b/src/shared/errors/__tests__/map-error-to-http.test.ts
@@ -15,6 +15,7 @@ import {
   AuthError,
   DomainError,
   InfraError,
+  ResponseValidationError,
   ValidationError,
 } from '@shared/errors/app-error'
 import { dbError } from '@shared/errors/db-errors'
@@ -30,6 +31,20 @@ vi.mock('@config/env', () => ({
 vi.mock('@sentry/node', () => ({
   captureException: vi.fn(),
 }))
+
+describe('mapErrorToHttp response validation', () => {
+  it('maps RESPONSE_VALIDATION_ERROR to 500 with a generic message and no leaked details', () => {
+    const { status, body, headers } = mapErrorToHttp(
+      new ResponseValidationError([{ path: ['data'], message: 'bad' }])
+    )
+
+    expect(status).toBe(500)
+    expect(headers?.['Retry-After']).toBeUndefined()
+    expect(body.code).toBe(ErrorCodes.RESPONSE_VALIDATION_ERROR)
+    expect(body.message).toMatch(/internal server error/i)
+    expect(body.meta?.details).toBeUndefined()
+  })
+})
 
 describe('mapErrorToHttp infra errors', () => {
   it('maps DB_ERROR to 503 with Retry-After, generic message and preserved code', () => {

--- a/src/shared/errors/app-error.ts
+++ b/src/shared/errors/app-error.ts
@@ -20,7 +20,7 @@
  * @see {@link mapErrorToHttp} — HTTP status and body mapping
  */
 
-import type { ErrorCode } from '@shared/errors/codes'
+import { type ErrorCode, ErrorCodes } from '@shared/errors/codes'
 import { BaseError } from '@shared/errors/base-error'
 
 // BaseError and ErrorSeverity are re-exported via the barrel at `@shared/errors`.
@@ -99,6 +99,33 @@ export class ValidationError extends BaseError {
     cause?: unknown
   ) {
     super('ValidationError', code, message, 'warn', details, cause)
+  }
+}
+
+/**
+ * Server-side contract violation: a route handler's output failed its declared
+ * response schema.
+ *
+ * @remarks
+ * Mapped to **500** with a generic client message (the schema issues stay in
+ * logs/Sentry, never leaked to clients). Not a client fault and not retryable,
+ * so it is distinct from {@link InfraError} (503 + `Retry-After`). Thrown by
+ * {@link withErrorHandling} when `options.responseSchema` rejects the payload.
+ */
+export class ResponseValidationError extends BaseError {
+  /**
+   * @param details - Structured schema issues (e.g. Zod `issues`) for logs
+   * @param cause - Optional underlying error
+   */
+  constructor(details?: unknown, cause?: unknown) {
+    super(
+      'ResponseValidationError',
+      ErrorCodes.RESPONSE_VALIDATION_ERROR,
+      'Response validation failed',
+      'error',
+      details,
+      cause
+    )
   }
 }
 

--- a/src/shared/errors/codes.ts
+++ b/src/shared/errors/codes.ts
@@ -48,6 +48,9 @@ export const ErrorCodes = {
   /** Upstream external API failure — HTTP 500, Sentry. */
   EXTERNAL_API_ERROR: 'EXTERNAL_API_ERROR',
 
+  /** Handler output failed its response schema — HTTP 500, Sentry. */
+  RESPONSE_VALIDATION_ERROR: 'RESPONSE_VALIDATION_ERROR',
+
   /** User profile/account not found — HTTP 404. */
   USER_NOT_FOUND: 'USER_NOT_FOUND',
   /** User id failed validation — HTTP 400. */

--- a/src/shared/errors/map-error-to-http.ts
+++ b/src/shared/errors/map-error-to-http.ts
@@ -46,6 +46,7 @@ import {
   AuthError,
   DomainError,
   InfraError,
+  ResponseValidationError,
   ValidationError,
 } from '@shared/errors/app-error'
 import { captureError } from '@shared/errors/capture-error'
@@ -113,6 +114,19 @@ export const mapErrorToHttp = (error: unknown): HttpErrorResponse => {
   if (error instanceof DomainError) {
     captureError(error, 'warning')
     return mapDomainErrorToHttp(error)
+  }
+
+  if (error instanceof ResponseValidationError) {
+    logger.error({ err: error }, 'Response validation error')
+    captureError(error)
+
+    return {
+      status: 500,
+      body: {
+        code: error.code,
+        message: 'Internal server error',
+      },
+    }
   }
 
   if (error instanceof InfraError) {

--- a/src/shared/http/with-error-handling-types.ts
+++ b/src/shared/http/with-error-handling-types.ts
@@ -10,6 +10,19 @@
  */
 
 import type { APIContext } from 'astro'
+import type { ZodType } from 'zod'
+
+/**
+ * Options for {@link withErrorHandling}.
+ */
+export interface WithErrorHandlingOptions {
+  /**
+   * Optional Zod schema validating the **success envelope** (the built
+   * `{ data, status, meta }`) before serialization. On mismatch the wrapper
+   * throws a `ResponseValidationError` → HTTP 500. Omit to skip validation.
+   */
+  responseSchema?: ZodType
+}
 
 /**
  * Value returned by a route handler before envelope serialization.

--- a/src/shared/http/with-error-handling.ts
+++ b/src/shared/http/with-error-handling.ts
@@ -34,7 +34,11 @@ import {
   jsonResponse,
   mergeResponseHeaders,
 } from '@shared/http/api-response-serialize-util'
-import type { RouteHandler } from './with-error-handling-types'
+import type {
+  RouteHandler,
+  WithErrorHandlingOptions,
+} from './with-error-handling-types'
+import { ResponseValidationError } from '@shared/errors/app-error'
 import { logger } from '@utils/logger-util'
 
 /**
@@ -59,7 +63,8 @@ import { logger } from '@utils/logger-util'
  * @see {@link HandlerResult}
  */
 export const withErrorHandling = <TContext extends APIContext>(
-  handler: RouteHandler<TContext>
+  handler: RouteHandler<TContext>,
+  options?: WithErrorHandlingOptions
 ): ((context: TContext) => Promise<Response>) => {
   return async (context: TContext) => {
     try {
@@ -69,6 +74,14 @@ export const withErrorHandling = <TContext extends APIContext>(
         result.status ?? 200,
         result.meta ?? {}
       )
+
+      if (options?.responseSchema) {
+        const validation = options.responseSchema.safeParse(payload)
+        if (!validation.success) {
+          throw new ResponseValidationError(validation.error.issues)
+        }
+      }
+
       const response = jsonResponse(payload, undefined, payload.status)
 
       if (result.headers) {


### PR DESCRIPTION
## What this does

Adds **response-schema validation** to the `withErrorHandling` HTTP wrapper, so routes guarantee — at runtime — that the response envelope matches its Zod contract before it goes out. Refactors the anime/music/user routes to the `withZodValidation(schema)(withErrorHandling(handler, { responseSchema }))` composition, removing manual `try/catch` blocks and repeated `mapErrorToHttp`/`jsonResponse` calls.

## Key changes

- **`withErrorHandling(handler, { responseSchema })`**: validates the built envelope (`{ data, status, meta }`). On mismatch it throws `ResponseValidationError`.
- **`ResponseValidationError`** (new, `RESPONSE_VALIDATION_ERROR`) → mapped to **500** with a generic message (no internal details leaked).
- **Migrated routes**: `GET /api/anime` (+ `:malId`, `/characters`, `/full`, `/staff`), `GET /api/music` (+ `:id`), `GET|POST|PATCH /api/user`.

## 🐛 Real bug surfaced by the wrapper

`userProfileSchema.avatar` used `z.url()` (absolute URL), but real avatars are relative media/proxy paths (`/placeholder.webp`). With response validation enabled, a **valid** profile would return **500 in production**. Loosened to `z.string()`. Anime card `imageUrl`/`smallImageUrl` stay `z.url()` (the mapper emits absolute URLs).

## Verification

`format` ✓ · `check` ✓ · `check:types` 0 errors ✓ · `test` 115 passed ✓ · `build` Complete ✓

## OpenSpec

Change: `api-response-schema-in-wrapper` (all tasks marked, verification complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API responses are now validated consistently across anime, music, and user endpoints.
  - Invalid server responses return a generic HTTP 500 error without exposing validation details.
  - User avatars now support both relative media paths and absolute URLs.

- **Bug Fixes**
  - Improved consistency of API error handling and response formatting.

- **Tests**
  - Added coverage for valid responses, malformed response data, and validation error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->