### PR TITLE
fix(ci): reference Postgres password from CI secret instead of hardcoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       # placeholders used by the code-quality gate above). Reach the service
       # containers via 127.0.0.1 (IPv4) — `localhost` can resolve to IPv6 `::1`
       # on the runner, which the containers' IPv4-only port maps refuse.
-      DATABASE_URL: postgres://anidev:anidev@127.0.0.1:5432/anidev
+      DATABASE_URL: postgres://anidev:${{ secrets.CI_POSTGRES_PASSWORD }}@127.0.0.1:5432/anidev
       REDIS_URL: redis://127.0.0.1:6379
       APP_BASE_URL: http://127.0.0.1:4331
       BETTER_AUTH_SECRET: e2e-secret-e2e-secret-e2e-secret-e2e!!
@@ -75,7 +75,7 @@ jobs:
         image: postgres:16-alpine
         env:
           POSTGRES_USER: anidev
-          POSTGRES_PASSWORD: anidev
+          POSTGRES_PASSWORD: ${{ secrets.CI_POSTGRES_PASSWORD }}
           POSTGRES_DB: anidev
         ports:
           - 5432:5432


### PR DESCRIPTION
## Summary
Replace hardcoded PostgreSQL credentials in the CI workflow with the `CI_POSTGRES_PASSWORD` repository secret.

## Changes
- Use `secrets.CI_POSTGRES_PASSWORD` in `DATABASE_URL`.
- Configure the PostgreSQL service container with the same secret.

## Testing
- Existing CI checks pass.