### PR TITLE
test: fix SonarQube code smells (toHaveLength, top-level await, conditional skip notes)

### DIFF
--- a/e2e/api/user-profile.spec.ts
+++ b/e2e/api/user-profile.spec.ts
@@ -32,7 +32,10 @@ test.describe('user profile lifecycle', () => {
   test('create, read, and update the caller profile', async ({
     authedRequest,
   }) => {
+    // Skip is runtime-conditional (drifted local DB), never unconditional: CI
+    // always migrates fresh, so the suite still runs there.
     test.skip(
+      // NOSONAR:S1607
       profileDrift,
       'profile.user_id has drifted from text — run against a freshly migrated DB'
     )
@@ -71,7 +74,9 @@ test.describe('user profile lifecycle', () => {
   })
 
   test('reading a non-existent profile is 404', async ({ request }) => {
+    // See the create/read/update test: conditional on DB drift, not ignored.
     test.skip(
+      // NOSONAR:S1607
       profileDrift,
       'profile.user_id has drifted from text — run against a freshly migrated DB'
     )

--- a/e2e/fixtures/seed-db.ts
+++ b/e2e/fixtures/seed-db.ts
@@ -62,13 +62,12 @@ export async function seedE2eDatabase(): Promise<void> {
   }
 }
 
-seedE2eDatabase()
-  .then(() => {
-    console.log(
-      `E2E seed complete: ${SEED_ANIME.length} anime, ${SEED_MUSIC.length} music`
-    )
-  })
-  .catch((error) => {
-    console.error('E2E seed failed:', error)
-    process.exit(1)
-  })
+try {
+  await seedE2eDatabase()
+  console.log(
+    `E2E seed complete: ${SEED_ANIME.length} anime, ${SEED_MUSIC.length} music`
+  )
+} catch (error) {
+  console.error('E2E seed failed:', error)
+  process.exit(1)
+}

--- a/src/domains/anime/__tests__/repositories/anime-list-filters-all.test.ts
+++ b/src/domains/anime/__tests__/repositories/anime-list-filters-all.test.ts
@@ -11,11 +11,11 @@ import { buildAnimeListFilters } from '@anime/repositories/anime-list/filters'
 
 describe('buildAnimeListFilters', () => {
   it('adds the not-adult floor for the safe (default) variant', () => {
-    expect(buildAnimeListFilters({}).length).toBe(1)
+    expect(buildAnimeListFilters({})).toHaveLength(1)
   })
 
   it('omits the not-adult floor for the full variant', () => {
-    expect(buildAnimeListFilters({ parentalVariant: 'full' }).length).toBe(0)
+    expect(buildAnimeListFilters({ parentalVariant: 'full' })).toHaveLength(0)
   })
 
   it('adds a condition per provided filter', () => {
@@ -32,7 +32,7 @@ describe('buildAnimeListFilters', () => {
       query: '  naruto  ',
     })
     // year, season, scoreMin, scoreMax, status, rating, type, genre, query = 9
-    expect(filters.length).toBe(9)
+    expect(filters).toHaveLength(9)
   })
 
   it('ignores blank query and empty arrays', () => {
@@ -42,6 +42,6 @@ describe('buildAnimeListFilters', () => {
       status: [],
       genre: [],
     })
-    expect(filters.length).toBe(0)
+    expect(filters).toHaveLength(0)
   })
 })

--- a/src/domains/anime/__tests__/repositories/anime-list-filters.test.ts
+++ b/src/domains/anime/__tests__/repositories/anime-list-filters.test.ts
@@ -88,11 +88,11 @@ describe('buildAnimeListFilters — parental floor', () => {
   })
 
   it('applies the safe floor when the variant is unset (fail-closed)', () => {
-    expect(buildAnimeListFilters({}).length).toBe(1)
+    expect(buildAnimeListFilters({})).toHaveLength(1)
   })
 
   it('full variant does not restrict ratings', () => {
-    expect(buildAnimeListFilters({ parentalVariant: 'full' }).length).toBe(0)
+    expect(buildAnimeListFilters({ parentalVariant: 'full' })).toHaveLength(0)
   })
 })
 

--- a/src/domains/search/__tests__/repositories/search-history.integration.test.ts
+++ b/src/domains/search/__tests__/repositories/search-history.integration.test.ts
@@ -51,7 +51,7 @@ describe.skipIf(!enabled)('searchHistoryRepository (integration)', () => {
     }
 
     const rows = await repo.listByUser(TEST_USER, 100)
-    expect(rows.length).toBe(50)
+    expect(rows).toHaveLength(50)
     expect(rows[0].query).toBe('q54')
     expect(rows[0].scope).toBe('anime')
   })
@@ -59,6 +59,6 @@ describe.skipIf(!enabled)('searchHistoryRepository (integration)', () => {
   it('clears all rows for the user', async () => {
     const removed = await repo.clearByUser(TEST_USER)
     expect(removed).toBeGreaterThan(0)
-    expect((await repo.listByUser(TEST_USER, 10)).length).toBe(0)
+    expect(await repo.listByUser(TEST_USER, 10)).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
Addresses SonarQube code smells in the test suite and E2E database seeding script.

## Changes
- Replaced `.length` assertions with `toHaveLength()` for clearer test expectations.
- Refactored E2E database seeding to use `async`/`await` with `try`/`catch` error handling.
- Documented runtime-conditional E2E test skips caused by local database schema drift.
- Added targeted `NOSONAR` annotations for conditional skip findings.

## Validation
- Existing checks pass (2/2).